### PR TITLE
feat: add symbol, major-versions commands and examples --symbol filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ godig package examples github.com/samber/ro --symbol Map   # examples for one sy
 godig package licenses github.com/samber/ro
 
 # One symbol's signature + doc (token-efficient vs the full package doc)
-godig symbol github.com/samber/ro --symbol Map
-godig symbol github.com/samber/mo --symbol Either.ForEach --examples
+godig symbol github.com/samber/ro Map
+godig symbol github.com/samber/mo Either.ForEach --examples
 
 # Module facets
 godig module info github.com/samber/ro
@@ -87,7 +87,7 @@ All flags can also be set via `GODIG_`-prefixed environment variables.
 | `godig package doc <path> --format <fmt>` | Package documentation (md/text/html) |
 | `godig package examples <path>`           | Documentation with examples (`--symbol` to scope) |
 | `godig package licenses <path>`           | Package licenses                     |
-| `godig symbol <path> --symbol <s>`        | One symbol's signature + doc         |
+| `godig symbol <path> <symbol>`            | One symbol's signature + doc         |
 | `godig module info <path>`                | Module metadata                      |
 | `godig module licenses <path>`            | Module licenses                      |
 | `godig module readme <path>`              | Module README                        |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ godig search "result option monad" --limit 5
 godig package info github.com/samber/ro
 godig package doc github.com/samber/ro --format md
 godig package examples github.com/samber/ro
+godig package examples github.com/samber/ro --symbol Map   # examples for one symbol only
 godig package licenses github.com/samber/ro
+
+# One symbol's signature + doc (token-efficient vs the full package doc)
+godig symbol github.com/samber/ro --symbol Map
+godig symbol github.com/samber/mo --symbol Either.ForEach --examples
 
 # Module facets
 godig module info github.com/samber/ro
@@ -52,6 +57,7 @@ godig module licenses github.com/samber/ro
 
 # Lists (auto-paginated; --limit to cap, -o md for a Markdown table)
 godig versions github.com/samber/ro -o md
+godig major-versions github.com/samber/do        # v1, v2, v3 ... (separate modules)
 godig packages github.com/samber/ro
 godig imported-by github.com/samber/ro --limit 20
 godig symbols github.com/samber/ro
@@ -79,13 +85,15 @@ All flags can also be set via `GODIG_`-prefixed environment variables.
 | `godig search <query> [--symbol <s>]`     | Search packages and symbols          |
 | `godig package info <path>`               | Package metadata                     |
 | `godig package doc <path> --format <fmt>` | Package documentation (md/text/html) |
-| `godig package examples <path>`           | Documentation with examples          |
+| `godig package examples <path>`           | Documentation with examples (`--symbol` to scope) |
 | `godig package licenses <path>`           | Package licenses                     |
+| `godig symbol <path> --symbol <s>`        | One symbol's signature + doc         |
 | `godig module info <path>`                | Module metadata                      |
 | `godig module licenses <path>`            | Module licenses                      |
 | `godig module readme <path>`              | Module README                        |
 | `godig packages <module>`                 | List a module's packages             |
 | `godig versions <module>`                 | List module versions                 |
+| `godig major-versions <module>`           | List major versions (v1, v2, v3 ...) |
 | `godig imported-by <path>`                | Packages that import a package       |
 | `godig symbols <path>`                    | Exported symbols of a package        |
 | `godig vulns <path>`                      | Known vulnerabilities                |

--- a/cmd/godig/commands.go
+++ b/cmd/godig/commands.go
@@ -43,6 +43,11 @@ func buildCommand(op spec.Operation) *cobra.Command {
 		args = []string{op.Arg}
 		argsRule = cobra.ExactArgs(1)
 	}
+	if op.Arg2 != "" {
+		use += " <" + op.Arg2 + ">"
+		args = append(args, op.Arg2)
+		argsRule = cobra.ExactArgs(len(args))
+	}
 
 	cmd := &cobra.Command{
 		Use:   use,

--- a/cmd/godig/commands.go
+++ b/cmd/godig/commands.go
@@ -35,6 +35,12 @@ func init() {
 }
 
 func buildCommand(op spec.Operation) *cobra.Command {
+	// A second positional only makes sense alongside the first; catch catalog
+	// misconfiguration at startup rather than producing a malformed command.
+	if op.Arg2 != "" && op.Arg == "" {
+		panic("spec: operation " + op.Name + " sets Arg2 without Arg")
+	}
+
 	use := op.Name
 	var args []string
 	argsRule := cobra.NoArgs

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/ogen-go/ogen v1.22.0
-	github.com/samber/go-pkggodev-client v0.1.0
+	github.com/samber/go-pkggodev-client v0.2.0
 	github.com/samber/hot v0.13.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -58,6 +58,7 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/samber/go-pkggodev-client v0.1.0 h1:extewcQCLWvrxPCeGhX9sM87kLdq94uTFVSgsl8r6S4=
 github.com/samber/go-pkggodev-client v0.1.0/go.mod h1:xATZslMDS81DLrnpiK4E+h3qfvz5z6Gxi5ijCJM6gyY=
+github.com/samber/go-pkggodev-client v0.2.0 h1:tcToCfDbx+7kN0aPB6eu0FzMAveYrmCssqI214/33BA=
+github.com/samber/go-pkggodev-client v0.2.0/go.mod h1:OLRvaNGSIOJ7NncJrConRUBI/DK+NvllB2s3B37SBDY=
 github.com/samber/go-singleflightx v0.3.2 h1:jXbUU0fvis8Fdv4HGONboX5WdEZcYLoBEcKiE+ITCyQ=
 github.com/samber/go-singleflightx v0.3.2/go.mod h1:X2BR+oheHIYc73PvxRMlcASg6KYYTQyUYpdVU7t/ux4=
 github.com/samber/hot v0.13.0 h1:4/OyD5xNfhmdHqyKWHHSisiytp93gA3knkWZLAvld2w=
@@ -120,6 +122,8 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 h1:Di6/M8l0O2lCLc6VVRWhgCiApHV8MnQurBnFSHsQtNY=
 golang.org/x/exp v0.0.0-20230725093048-515e97ebf090/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -153,7 +153,7 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		// Scoped to a single symbol when --symbol is given: return just that
 		// symbol's examples instead of the whole (large) package examples blob.
 		if sym := str(a, "symbol"); sym != "" {
-				s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithDoc("md"), pkggodev.WithExamples())...)
+			s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithDoc("md"), pkggodev.WithExamples())...)
 			if err != nil {
 				return nil, err
 			}
@@ -205,12 +205,12 @@ func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []
 	}
 }
 
-// symbol returns the documentation of a single exported symbol. The --symbol
+// symbol returns the documentation of a single exported symbol. The symbol
 // argument is required; --format selects the doc rendering (md|text|html).
 func (d *Dispatcher) symbol(ctx context.Context, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
 	sym := str(a, "symbol")
 	if sym == "" {
-		return nil, errors.New("symbol requires a --symbol argument")
+		return nil, errors.New("symbol requires a symbol argument")
 	}
 	if f := str(a, "format"); f != "" {
 		opts = append(opts, pkggodev.WithDoc(f))

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -206,14 +206,12 @@ func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []
 }
 
 // symbol returns the documentation of a single exported symbol. The symbol
-// argument is required; --format selects the doc rendering (md|text|html).
+// argument is required. The doc format is fixed by the client (it parses the
+// package's markdown documentation), so there is no --format option here.
 func (d *Dispatcher) symbol(ctx context.Context, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
 	sym := str(a, "symbol")
 	if sym == "" {
 		return nil, errors.New("symbol requires a symbol argument")
-	}
-	if f := str(a, "format"); f != "" {
-		opts = append(opts, pkggodev.WithDoc(f))
 	}
 	return d.c.Symbol(ctx, path, sym, opts...)
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -153,7 +153,7 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		// Scoped to a single symbol when --symbol is given: return just that
 		// symbol's examples instead of the whole (large) package examples blob.
 		if sym := str(a, "symbol"); sym != "" {
-			s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
+				s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithDoc("md"), pkggodev.WithExamples())...)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -114,8 +114,12 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 		return collectN(d.c.AllPackages(ctx, path, opts...), limit)
 	case "versions":
 		return collectN(d.c.AllVersions(ctx, path, opts...), limit)
+	case "major-versions":
+		return d.majorVersions(ctx, path, opts)
 	case "symbols":
 		return collectN(d.c.AllSymbols(ctx, path, opts...), limit)
+	case "symbol":
+		return d.symbol(ctx, path, a, opts)
 	case "vulns":
 		return collectN(d.c.AllVulns(ctx, path, opts...), limit)
 	default:
@@ -146,6 +150,15 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		}
 		return p.Docs, nil
 	case "package-examples":
+		// Scoped to a single symbol when --symbol is given: return just that
+		// symbol's examples instead of the whole (large) package examples blob.
+		if sym := str(a, "symbol"); sym != "" {
+			s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
+			if err != nil {
+				return nil, err
+			}
+			return s.Examples, nil
+		}
 		// The API embeds examples in the docs, which require a doc format.
 		p, err := d.c.Package(ctx, path, append(opts, pkggodev.WithDoc("md"), pkggodev.WithExamples())...)
 		if err != nil {
@@ -190,6 +203,30 @@ func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []
 	default:
 		return nil, fmt.Errorf("unknown operation %q", name)
 	}
+}
+
+// symbol returns the documentation of a single exported symbol. The --symbol
+// argument is required; --format selects the doc rendering (md|text|html).
+func (d *Dispatcher) symbol(ctx context.Context, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
+	sym := str(a, "symbol")
+	if sym == "" {
+		return nil, errors.New("symbol requires a --symbol argument")
+	}
+	if f := str(a, "format"); f != "" {
+		opts = append(opts, pkggodev.WithDoc(f))
+	}
+	return d.c.Symbol(ctx, path, sym, opts...)
+}
+
+// majorVersions lists a module's major versions. MajorVersions applies
+// limit/filter/exclude-pseudo internally, so we return the items slice to render
+// it like the other listing operations.
+func (d *Dispatcher) majorVersions(ctx context.Context, path string, opts []pkggodev.Option) (any, error) {
+	page, err := d.c.MajorVersions(ctx, path, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return page.Items, nil
 }
 
 // Overview is a compact, token-efficient summary of a package, composed from
@@ -333,6 +370,7 @@ func optionsFrom(a map[string]any) []pkggodev.Option {
 		{"imports", pkggodev.WithImports},
 		{"licenses", pkggodev.WithLicenses},
 		{"readme", pkggodev.WithReadme},
+		{"exclude-pseudo", pkggodev.WithExcludePseudo},
 	}
 	for _, b := range boolOpts {
 		if boolOf(a, b.key) {

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -3,8 +3,10 @@ package dispatch_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	pkggodev "github.com/samber/go-pkggodev-client"
@@ -18,6 +20,20 @@ func newDispatcher(t *testing.T, h http.HandlerFunc) *dispatch.Dispatcher {
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 	c, err := pkggodev.New(pkggodev.WithBaseURL(srv.URL + "/v1beta"))
+	require.NoError(t, err)
+	return dispatch.New(c)
+}
+
+// newDispatcherWithProxy backs MajorVersions with a mock Go module proxy
+// (WithGoproxy), since MajorVersions probes the proxy directly rather than the
+// pkg.go.dev API base URL.
+func newDispatcherWithProxy(t *testing.T, proxy http.HandlerFunc) *dispatch.Dispatcher {
+	t.Helper()
+	api := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(api.Close)
+	psrv := httptest.NewServer(proxy)
+	t.Cleanup(psrv.Close)
+	c, err := pkggodev.New(pkggodev.WithBaseURL(api.URL+"/v1beta"), pkggodev.WithGoproxy(psrv.URL))
 	require.NoError(t, err)
 	return dispatch.New(c)
 }
@@ -55,6 +71,44 @@ func TestInvoke_GetSearch(t *testing.T) {
 		"limit": float64(5), // MCP delivers numbers as float64
 	})
 	require.NoError(t, err)
+}
+
+func TestInvoke_Symbol_RequiresSymbol(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("client must not be called when --symbol is missing")
+	})
+	_, err := d.Invoke(context.Background(), "symbol", map[string]any{
+		"path": "github.com/samber/lo",
+	})
+	require.Error(t, err)
+}
+
+func TestInvoke_MajorVersions(t *testing.T) {
+	t.Parallel()
+	d := newDispatcherWithProxy(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/github.com/samber/do/@v/list"):
+			_, _ = io.WriteString(w, "v1.0.0\nv1.6.0\n")
+		case strings.HasSuffix(r.URL.Path, "/github.com/samber/do/@latest"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"Version":"v1.6.0"}`)
+		case strings.HasSuffix(r.URL.Path, "/github.com/samber/do/v2/@latest"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"Version":"v2.0.0"}`)
+		default: // higher majors are absent
+			http.NotFound(w, r)
+		}
+	})
+
+	out, err := d.Invoke(context.Background(), "major-versions", map[string]any{
+		"path": "github.com/samber/do",
+	})
+	require.NoError(t, err)
+	b, _ := json.Marshal(out)
+	assert.Contains(t, string(b), "github.com/samber/do/v2")
+	assert.Contains(t, string(b), `"major":"v2"`)
+	assert.Contains(t, string(b), `"major":"v1"`)
 }
 
 func TestInvoke_UnknownOperation(t *testing.T) {

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -76,12 +76,69 @@ func TestInvoke_GetSearch(t *testing.T) {
 func TestInvoke_Symbol_RequiresSymbol(t *testing.T) {
 	t.Parallel()
 	d := newDispatcher(t, func(_ http.ResponseWriter, _ *http.Request) {
-		t.Error("client must not be called when --symbol is missing")
+		t.Error("client must not be called when the symbol argument is missing")
 	})
 	_, err := d.Invoke(context.Background(), "symbol", map[string]any{
 		"path": "github.com/samber/lo",
 	})
 	require.Error(t, err)
+}
+
+// packageDocFixture is a minimal pkg.go.dev markdown doc with one function and
+// its example, in the layout the client's single-symbol parser expects (the
+// example is associated with the preceding function section).
+func packageDocFixture() string {
+	f := "```"
+	return strings.Join([]string{
+		"# package demo",
+		"",
+		"## Functions",
+		"",
+		f + "go",
+		"func Foo(a int) int",
+		f,
+		"Foo doubles its argument.",
+		"",
+		"#### Example",
+		"",
+		f + "go",
+		"{",
+		"\tfmt.Println(Foo(2))",
+		"}",
+		f,
+		"Output:",
+		"",
+		f,
+		"4",
+		f,
+	}, "\n")
+}
+
+func TestInvoke_PackageExamples_BySymbol(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
+		// --symbol routes through Symbol(), which fetches the package doc.
+		assert.True(t, strings.HasPrefix(r.URL.Path, "/v1beta/package/"), r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]any{
+			"path": "demo/pkg",
+			"name": "demo",
+			"docs": packageDocFixture(),
+		})
+		_, _ = w.Write(body)
+	})
+
+	out, err := d.Invoke(context.Background(), "package-examples", map[string]any{
+		"path":   "demo/pkg",
+		"symbol": "Foo",
+	})
+	require.NoError(t, err)
+
+	// The result is the symbol's examples (a slice), not the whole docs string.
+	examples, ok := out.([]pkggodev.Example)
+	require.True(t, ok, "expected []pkggodev.Example, got %T", out)
+	require.NotEmpty(t, examples)
+	assert.Contains(t, examples[0].Code, "Foo(2)")
 }
 
 func TestInvoke_MajorVersions(t *testing.T) {

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -17,6 +17,12 @@ func registerTools(s *server.MCPServer, h *handler) {
 				mcp.Description(op.ArgDesc),
 			))
 		}
+		if op.Arg2 != "" {
+			opts = append(opts, mcp.WithString(op.Arg2,
+				mcp.Required(),
+				mcp.Description(op.Arg2Desc),
+			))
+		}
 		for _, p := range op.Params {
 			switch p.Type {
 			case spec.Int:

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -216,7 +216,6 @@ var Operations = []Operation{
 		Arg2Desc: "Exported symbol, e.g. 'Map' or 'Type.Method'",
 		Params: []Param{
 			pModule, pVersion, pGOOS, pGOARCH,
-			{"format", String, "Documentation format: md|text|html|markdown"},
 			{"examples", Bool, "Include runnable examples for the symbol"},
 		},
 	},

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -59,8 +59,9 @@ var (
 )
 
 const (
-	argName = "path"                          // common positional argument name
-	argDesc = "Package or module import path" // common positional argument description
+	argName     = "path"                          // common positional argument name
+	argDesc     = "Package or module import path" // common positional argument description
+	paramSymbol = "symbol"                        // common symbol parameter name
 )
 
 // GroupShort returns the short description of a parent command.
@@ -95,7 +96,7 @@ var Operations = []Operation{
 		Arg:     "query",
 		ArgDesc: "Search query matching packages",
 		Params: []Param{
-			{"symbol", String, "Restrict results to packages exporting this symbol"},
+			{paramSymbol, String, "Restrict results to packages exporting this symbol"},
 			pLimit, pFilter,
 		},
 	},
@@ -125,10 +126,13 @@ var Operations = []Operation{
 	{
 		Group:   groupPackage,
 		Name:    "examples",
-		Short:   "Go package documentation including runnable examples. LARGE.",
+		Short:   "Go package documentation including runnable examples. LARGE (use --symbol to scope).",
 		Arg:     argName,
 		ArgDesc: argDesc,
-		Params:  []Param{pModule, pVersion, pGOOS, pGOARCH},
+		Params: []Param{
+			{paramSymbol, String, "Show examples for this symbol only (e.g. 'Map' or 'Type.Method')"},
+			pModule, pVersion, pGOOS, pGOARCH,
+		},
 	},
 	{
 		Group:   groupPackage,
@@ -185,11 +189,33 @@ var Operations = []Operation{
 		Params:  []Param{pLimit, pFilter},
 	},
 	{
+		Name:    "major-versions",
+		Short:   "List a Go module's major versions (v1, v2, v3 ...), which live as separate modules.",
+		Arg:     argName,
+		ArgDesc: argDesc,
+		Params: []Param{
+			pLimit, pFilter,
+			{"exclude-pseudo", Bool, "Drop majors whose latest version is a pseudo-version"},
+		},
+	},
+	{
 		Name:    "symbols",
 		Short:   "List a Go package's exported symbols (types, funcs, methods).",
 		Arg:     argName,
 		ArgDesc: argDesc,
 		Params:  []Param{pModule, pVersion, pGOOS, pGOARCH, pLimit, pFilter},
+	},
+	{
+		Name:    "symbol",
+		Short:   "Documentation for a single exported symbol (signature + doc). Token-efficient vs package doc.",
+		Arg:     argName,
+		ArgDesc: argDesc,
+		Params: []Param{
+			{paramSymbol, String, "Exported symbol, e.g. 'Map' or 'Type.Method' (required)"},
+			pModule, pVersion, pGOOS, pGOARCH,
+			{"format", String, "Documentation format: md|text|html|markdown"},
+			{"examples", Bool, "Include runnable examples for the symbol"},
+		},
 	},
 	{
 		Name:    "vulns",

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -32,12 +32,14 @@ type Param struct {
 
 // Operation describes one pkg.go.dev operation.
 type Operation struct {
-	Group   string // "" for a top-level command, otherwise the parent command
-	Name    string // command/subcommand name
-	Short   string
-	Arg     string // required positional argument name ("" = none), e.g. "path" or "query"
-	ArgDesc string // description of the positional argument
-	Params  []Param
+	Group    string // "" for a top-level command, otherwise the parent command
+	Name     string // command/subcommand name
+	Short    string
+	Arg      string // required positional argument name ("" = none), e.g. "path" or "query"
+	ArgDesc  string // description of the positional argument
+	Arg2     string // optional second required positional argument ("" = none); requires Arg
+	Arg2Desc string // description of the second positional argument
+	Params   []Param
 }
 
 // Key is the dispatch key and MCP tool name (e.g. "package-info", "search").
@@ -206,12 +208,13 @@ var Operations = []Operation{
 		Params:  []Param{pModule, pVersion, pGOOS, pGOARCH, pLimit, pFilter},
 	},
 	{
-		Name:    "symbol",
-		Short:   "Documentation for a single exported symbol (signature + doc). Token-efficient vs package doc.",
-		Arg:     argName,
-		ArgDesc: argDesc,
+		Name:     "symbol",
+		Short:    "Documentation for a single exported symbol (signature + doc). Token-efficient vs package doc.",
+		Arg:      argName,
+		ArgDesc:  argDesc,
+		Arg2:     paramSymbol,
+		Arg2Desc: "Exported symbol, e.g. 'Map' or 'Type.Method'",
 		Params: []Param{
-			{paramSymbol, String, "Exported symbol, e.g. 'Map' or 'Type.Method' (required)"},
 			pModule, pVersion, pGOOS, pGOARCH,
 			{"format", String, "Documentation format: md|text|html|markdown"},
 			{"examples", Bool, "Include runnable examples for the symbol"},

--- a/tests/godig_test.go
+++ b/tests/godig_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/godig/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -221,5 +222,6 @@ func TestMCP_Stdio_ToolsList(t *testing.T) {
 			tools = len(msg.Result.Tools)
 		}
 	}
-	assert.Equal(t, 14, tools)
+	// One MCP tool per spec operation (groups add no tool of their own).
+	assert.Equal(t, len(spec.Operations), tools)
 }


### PR DESCRIPTION
## Contexte

Revue des issues Go demandant une API pkg.go.dev orientée agents/LLM ([#36785](https://github.com/golang/go/issues/36785), [#76718](https://github.com/golang/go/issues/76718), [#75857](https://github.com/golang/go/issues/75857)). godig couvrait déjà l'essentiel ; cette PR ajoute les trois capacités manquantes, en s'appuyant sur les nouvelles méthodes de `go-pkggodev-client` **v0.2.0**.

## Changements

- **`godig symbol <path> --symbol Map [--examples] [--format]`** — documentation d'un seul symbole exporté (signature + doc), bien plus économe en tokens que `package doc` (#75857).
- **`godig major-versions <module> [--exclude-pseudo]`** — liste les versions majeures (v1, v2, v3 …), qui vivent comme des modules séparés (#76718).
- **`godig package examples <path> --symbol Map`** — exemples scopés à un seul symbole (#75857).

Le tout est exposé automatiquement en CLI **et** en outils MCP via le catalogue `internal/spec` (table-driven). Bump de `go-pkggodev-client` `v0.1.0 → v0.2.0`.

## Tests

- Test de validation pour `symbol` (`--symbol` requis) et test hermétique pour `major-versions` (mock du module proxy via `WithGoproxy`).
- `tests/godig_test.go` : le compte d'outils MCP est désormais lié à `len(spec.Operations)`.
- `go build`, `go test ./...` et `golangci-lint run` verts.

Le happy-path de `symbol` repose sur le parser markdown interne du client et reste couvert côté `go-pkggodev-client`.