### PR TITLE
feat: use samber/godig/{version} as HTTP User-Agent

### DIFF
--- a/cmd/godig/root.go
+++ b/cmd/godig/root.go
@@ -80,7 +80,7 @@ func newDispatcher() (*dispatch.Dispatcher, error) {
 			Timeout:   timeout,
 			Transport: logging.Transport(nil),
 		}),
-		pkggodev.WithUserAgent("godig"),
+		pkggodev.WithUserAgent("samber/godig/"+version),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

The pkg.go.dev API client previously sent a static `godig` User-Agent. This changes it to the conventional `samber/godig/{version}` form, where `{version}` is the build-time injected version (`dev` for local builds, the release tag otherwise).

## Changes

- `cmd/godig/root.go`: `WithUserAgent("godig")` → `WithUserAgent("samber/godig/"+version)`

This makes outbound requests self-identifying with the project and the running version.