### PR TITLE
feat!: split symbol into doc/examples, extract package imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ All flags can also be set via `GODIG_`-prefixed environment variables.
 | `godig overview <path>`                   | One-call compact summary (start here)|
 | `godig search <query> [--symbol <s>]`     | Search packages and symbols          |
 | `godig package info <path>`               | Package metadata                     |
-| `godig package imports <path>`            | Packages a package imports           |
+| `godig package imports <path>`            | Packages that a package imports      |
 | `godig package doc <path> --format <fmt>` | Package documentation (md/text/html) |
 | `godig package examples <path>`           | Documentation with examples (`--symbol` to scope) |
 | `godig package licenses <path>`           | Package licenses                     |

--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ godig search "result option monad" --limit 5
 
 # Package facets
 godig package info github.com/samber/ro
+godig package imports github.com/samber/ro
 godig package doc github.com/samber/ro --format md
 godig package examples github.com/samber/ro
 godig package examples github.com/samber/ro --symbol Map   # examples for one symbol only
 godig package licenses github.com/samber/ro
 
-# One symbol's signature + doc (token-efficient vs the full package doc)
-godig symbol github.com/samber/ro Map
-godig symbol github.com/samber/mo Either.ForEach --examples
+# Single symbol (token-efficient vs the full package doc/examples)
+godig symbol doc github.com/samber/ro Map
+godig symbol examples github.com/samber/mo Either.ForEach
 
 # Module facets
 godig module info github.com/samber/ro
@@ -84,10 +85,12 @@ All flags can also be set via `GODIG_`-prefixed environment variables.
 | `godig overview <path>`                   | One-call compact summary (start here)|
 | `godig search <query> [--symbol <s>]`     | Search packages and symbols          |
 | `godig package info <path>`               | Package metadata                     |
+| `godig package imports <path>`            | Packages a package imports           |
 | `godig package doc <path> --format <fmt>` | Package documentation (md/text/html) |
 | `godig package examples <path>`           | Documentation with examples (`--symbol` to scope) |
 | `godig package licenses <path>`           | Package licenses                     |
-| `godig symbol <path> <symbol>`            | One symbol's signature + doc         |
+| `godig symbol doc <path> <symbol>`        | One symbol's signature + doc         |
+| `godig symbol examples <path> <symbol>`   | One symbol's runnable examples       |
 | `godig module info <path>`                | Module metadata                      |
 | `godig module licenses <path>`            | Module licenses                      |
 | `godig module readme <path>`              | Module README                        |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/ogen-go/ogen v1.22.0
-	github.com/samber/go-pkggodev-client v0.2.0
+	github.com/samber/go-pkggodev-client v0.3.0
 	github.com/samber/hot v0.13.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/samber/go-pkggodev-client v0.1.0 h1:extewcQCLWvrxPCeGhX9sM87kLdq94uTF
 github.com/samber/go-pkggodev-client v0.1.0/go.mod h1:xATZslMDS81DLrnpiK4E+h3qfvz5z6Gxi5ijCJM6gyY=
 github.com/samber/go-pkggodev-client v0.2.0 h1:tcToCfDbx+7kN0aPB6eu0FzMAveYrmCssqI214/33BA=
 github.com/samber/go-pkggodev-client v0.2.0/go.mod h1:OLRvaNGSIOJ7NncJrConRUBI/DK+NvllB2s3B37SBDY=
+github.com/samber/go-pkggodev-client v0.3.0 h1:nrgVSXtvd6H5y09eKFrup8BQKL6S2YzxgRohzXsCfdA=
+github.com/samber/go-pkggodev-client v0.3.0/go.mod h1:tQKn0VDMRjTWCisR5uRX+wxZFkBs4jVkRIykApoyKpk=
 github.com/samber/go-singleflightx v0.3.2 h1:jXbUU0fvis8Fdv4HGONboX5WdEZcYLoBEcKiE+ITCyQ=
 github.com/samber/go-singleflightx v0.3.2/go.mod h1:X2BR+oheHIYc73PvxRMlcASg6KYYTQyUYpdVU7t/ux4=
 github.com/samber/hot v0.13.0 h1:4/OyD5xNfhmdHqyKWHHSisiytp93gA3knkWZLAvld2w=

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -181,7 +181,11 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		if err != nil {
 			return nil, err
 		}
-		return p.Imports, nil
+		imports := p.Imports
+		if imports == nil {
+			imports = []string{}
+		}
+		return imports, nil
 	case "package-doc":
 		format := str(a, "format")
 		if format == "" {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -92,6 +92,9 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 	if strings.HasPrefix(name, "module-") {
 		return d.routeModule(ctx, name, path, opts)
 	}
+	if strings.HasPrefix(name, "symbol-") {
+		return d.routeSymbol(ctx, name, path, a, opts)
+	}
 
 	// Listing operations auto-paginate (AllX) and return the full slice of items,
 	// so the table output shows rows and never a nextToken cursor. --limit caps
@@ -118,8 +121,6 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 		return d.majorVersions(ctx, path, opts)
 	case "symbols":
 		return collectN(d.c.AllSymbols(ctx, path, opts...), limit)
-	case "symbol":
-		return d.symbol(ctx, path, a, opts)
 	case "vulns":
 		return collectN(d.c.AllVulns(ctx, path, opts...), limit)
 	default:
@@ -138,7 +139,14 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		}
 		p.Docs = ""
 		p.Licenses = nil
+		p.Imports = nil
 		return p, nil
+	case "package-imports":
+		p, err := d.c.Package(ctx, path, append(opts, pkggodev.WithImports())...)
+		if err != nil {
+			return nil, err
+		}
+		return p.Imports, nil
 	case "package-doc":
 		format := str(a, "format")
 		if format == "" {
@@ -152,8 +160,9 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 	case "package-examples":
 		// Scoped to a single symbol when --symbol is given: return just that
 		// symbol's examples instead of the whole (large) package examples blob.
+		// Symbol() always parses the markdown doc, so only WithExamples matters.
 		if sym := str(a, "symbol"); sym != "" {
-			s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithDoc("md"), pkggodev.WithExamples())...)
+			s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
 			if err != nil {
 				return nil, err
 			}
@@ -205,15 +214,29 @@ func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []
 	}
 }
 
-// symbol returns the documentation of a single exported symbol. The symbol
-// argument is required. The doc format is fixed by the client (it parses the
-// package's markdown documentation), so there is no --format option here.
-func (d *Dispatcher) symbol(ctx context.Context, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
+// routeSymbol handles the `symbol` subcommands for a single exported symbol:
+// `doc` returns the signature + documentation, `examples` returns just the
+// symbol's runnable examples. The symbol argument is required. The doc format is
+// fixed by the client (it parses the package's markdown documentation).
+func (d *Dispatcher) routeSymbol(ctx context.Context, name, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
 	sym := str(a, "symbol")
 	if sym == "" {
 		return nil, errors.New("symbol requires a symbol argument")
 	}
-	return d.c.Symbol(ctx, path, sym, opts...)
+	switch name {
+	case "symbol-doc":
+		return d.c.Symbol(ctx, path, sym, opts...)
+	case "symbol-examples":
+		// Symbol() always parses the package's markdown doc, so only WithExamples
+		// matters here (WithDoc is a no-op on this call).
+		s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
+		if err != nil {
+			return nil, err
+		}
+		return s.Examples, nil
+	default:
+		return nil, fmt.Errorf("unknown operation %q", name)
+	}
 }
 
 // majorVersions lists a module's major versions. MajorVersions applies
@@ -346,28 +369,16 @@ func optionsFrom(a map[string]any) []pkggodev.Option {
 		}
 	}
 
-	examples := boolOf(a, "examples")
-	doc := str(a, "doc")
-	if doc == "" && examples {
-		// The API rejects examples without a documentation format (HTTP 400),
-		// so default to markdown when the user asks for examples.
-		doc = "md"
-	}
-	if doc != "" {
-		o = append(o, pkggodev.WithDoc(doc))
-	}
 	if n := intOf(a, "limit"); n > 0 {
 		o = append(o, pkggodev.WithLimit(n))
 	}
 
+	// Facet options (doc/examples/imports/licenses/readme) are applied explicitly
+	// by the routePackage/routeSymbol handlers, not derived from generic flags.
 	boolOpts := []struct {
 		key string
 		fn  func() pkggodev.Option
 	}{
-		{"examples", pkggodev.WithExamples},
-		{"imports", pkggodev.WithImports},
-		{"licenses", pkggodev.WithLicenses},
-		{"readme", pkggodev.WithReadme},
 		{"exclude-pseudo", pkggodev.WithExcludePseudo},
 	}
 	for _, b := range boolOpts {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ogen-go/ogen/validate"
 	pkggodev "github.com/samber/go-pkggodev-client"
@@ -106,6 +107,11 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 		if str(a, "query") == "" {
 			return nil, errors.New("search requires a query argument")
 		}
+		// WithSymbol only applies to search (it restricts results to packages
+		// exporting the symbol); the symbol routes pass it positionally instead.
+		if sym := str(a, "symbol"); sym != "" {
+			opts = append(opts, pkggodev.WithSymbol(sym))
+		}
 		return collectN(d.c.AllSearch(ctx, opts...), limit)
 	case "imported-by":
 		paths, err := collectN(d.c.AllImportedBy(ctx, path, opts...), limit)
@@ -128,6 +134,38 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 	}
 }
 
+// PackageInfo is the metadata-only projection returned by `package info`.
+// Building it from an allow-list (rather than nilling heavy fields on
+// pkggodev.Package) keeps the payload compact and fails safe: a new field on the
+// client struct is never leaked unless it is explicitly added here.
+type PackageInfo struct {
+	Path              string `json:"path"`
+	ModulePath        string `json:"modulePath,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Synopsis          string `json:"synopsis,omitempty"`
+	Version           string `json:"version,omitempty"`
+	Goos              string `json:"goos,omitempty"`
+	Goarch            string `json:"goarch,omitempty"`
+	IsLatest          bool   `json:"isLatest"`
+	IsRedistributable bool   `json:"isRedistributable"`
+	IsStandardLibrary bool   `json:"isStandardLibrary"`
+}
+
+func newPackageInfo(p *pkggodev.Package) PackageInfo {
+	return PackageInfo{
+		Path:              p.Path,
+		ModulePath:        p.ModulePath,
+		Name:              p.Name,
+		Synopsis:          p.Synopsis,
+		Version:           p.Version,
+		Goos:              p.Goos,
+		Goarch:            p.Goarch,
+		IsLatest:          p.IsLatest,
+		IsRedistributable: p.IsRedistributable,
+		IsStandardLibrary: p.IsStandardLibrary,
+	}
+}
+
 // routePackage handles the `package` subcommands, projecting the response to the
 // requested facet only (no basic info on doc/examples/licenses).
 func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
@@ -137,10 +175,7 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		if err != nil {
 			return nil, err
 		}
-		p.Docs = ""
-		p.Licenses = nil
-		p.Imports = nil
-		return p, nil
+		return newPackageInfo(p), nil
 	case "package-imports":
 		p, err := d.c.Package(ctx, path, append(opts, pkggodev.WithImports())...)
 		if err != nil {
@@ -180,6 +215,32 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 	}
 }
 
+// ModuleInfo is the metadata-only projection returned by `module info`.
+// See PackageInfo for the allow-list rationale.
+type ModuleInfo struct {
+	Path              string    `json:"path"`
+	Version           string    `json:"version,omitempty"`
+	RepoURL           string    `json:"repoUrl,omitempty"`
+	CommitTime        time.Time `json:"commitTime,omitzero"`
+	HasGoMod          bool      `json:"hasGoMod"`
+	IsLatest          bool      `json:"isLatest"`
+	IsRedistributable bool      `json:"isRedistributable"`
+	IsStandardLibrary bool      `json:"isStandardLibrary"`
+}
+
+func newModuleInfo(m *pkggodev.Module) ModuleInfo {
+	return ModuleInfo{
+		Path:              m.Path,
+		Version:           m.Version,
+		RepoURL:           m.RepoURL,
+		CommitTime:        m.CommitTime,
+		HasGoMod:          m.HasGoMod,
+		IsLatest:          m.IsLatest,
+		IsRedistributable: m.IsRedistributable,
+		IsStandardLibrary: m.IsStandardLibrary,
+	}
+}
+
 // routeModule handles the `module` subcommands.
 func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []pkggodev.Option) (any, error) {
 	switch name {
@@ -188,10 +249,7 @@ func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []
 		if err != nil {
 			return nil, err
 		}
-		m.Licenses = nil
-		m.Readme = pkggodev.Readme{}
-		m.GoModContents = ""
-		return m, nil
+		return newModuleInfo(m), nil
 	case "module-licenses":
 		m, err := d.c.Module(ctx, path, append(opts, pkggodev.WithLicenses())...)
 		if err != nil {
@@ -360,7 +418,6 @@ func optionsFrom(a map[string]any) []pkggodev.Option {
 		{"module", pkggodev.WithModule},
 		{"filter", pkggodev.WithFilter},
 		{"query", pkggodev.WithQuery},
-		{"symbol", pkggodev.WithSymbol},
 		{"goos", pkggodev.WithGOOS},
 		{"goarch", pkggodev.WithGOARCH},
 	}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -160,13 +160,8 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 	case "package-examples":
 		// Scoped to a single symbol when --symbol is given: return just that
 		// symbol's examples instead of the whole (large) package examples blob.
-		// Symbol() always parses the markdown doc, so only WithExamples matters.
 		if sym := str(a, "symbol"); sym != "" {
-			s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
-			if err != nil {
-				return nil, err
-			}
-			return s.Examples, nil
+			return d.symbolExamples(ctx, path, sym, opts)
 		}
 		// The API embeds examples in the docs, which require a doc format.
 		p, err := d.c.Package(ctx, path, append(opts, pkggodev.WithDoc("md"), pkggodev.WithExamples())...)
@@ -227,16 +222,22 @@ func (d *Dispatcher) routeSymbol(ctx context.Context, name, path string, a map[s
 	case "symbol-doc":
 		return d.c.Symbol(ctx, path, sym, opts...)
 	case "symbol-examples":
-		// Symbol() always parses the package's markdown doc, so only WithExamples
-		// matters here (WithDoc is a no-op on this call).
-		s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
-		if err != nil {
-			return nil, err
-		}
-		return s.Examples, nil
+		return d.symbolExamples(ctx, path, sym, opts)
 	default:
 		return nil, fmt.Errorf("unknown operation %q", name)
 	}
+}
+
+// symbolExamples returns just the runnable examples of a single exported symbol.
+// Symbol() always parses the package's markdown doc, so only WithExamples matters
+// here (WithDoc is a no-op on this call). Shared by `symbol examples` and
+// `package examples --symbol`.
+func (d *Dispatcher) symbolExamples(ctx context.Context, path, sym string, opts []pkggodev.Option) ([]pkggodev.Example, error) {
+	s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
+	if err != nil {
+		return nil, err
+	}
+	return s.Examples, nil
 }
 
 // majorVersions lists a module's major versions. MajorVersions applies
@@ -374,17 +375,10 @@ func optionsFrom(a map[string]any) []pkggodev.Option {
 	}
 
 	// Facet options (doc/examples/imports/licenses/readme) are applied explicitly
-	// by the routePackage/routeSymbol handlers, not derived from generic flags.
-	boolOpts := []struct {
-		key string
-		fn  func() pkggodev.Option
-	}{
-		{"exclude-pseudo", pkggodev.WithExcludePseudo},
-	}
-	for _, b := range boolOpts {
-		if boolOf(a, b.key) {
-			o = append(o, b.fn())
-		}
+	// by the routePackage/routeSymbol handlers, not derived from generic flags;
+	// exclude-pseudo is the only bool flag left in the generic path.
+	if boolOf(a, "exclude-pseudo") {
+		o = append(o, pkggodev.WithExcludePseudo())
 	}
 
 	return o

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -38,22 +38,23 @@ func newDispatcherWithProxy(t *testing.T, proxy http.HandlerFunc) *dispatch.Disp
 	return dispatch.New(c)
 }
 
-func TestInvoke_GetPackage(t *testing.T) {
+func TestInvoke_PackageImports(t *testing.T) {
 	t.Parallel()
 	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1beta/package/github.com/samber/lo", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("imports"))
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"path":"github.com/samber/lo","name":"lo"}`))
+		_, _ = w.Write([]byte(`{"path":"github.com/samber/lo","name":"lo","imports":["fmt","strings"]}`))
 	})
 
-	out, err := d.Invoke(context.Background(), "package-info", map[string]any{
-		"path":    "github.com/samber/lo",
-		"imports": true,
+	out, err := d.Invoke(context.Background(), "package-imports", map[string]any{
+		"path": "github.com/samber/lo",
 	})
 	require.NoError(t, err)
-	b, _ := json.Marshal(out)
-	assert.Contains(t, string(b), `"github.com/samber/lo"`)
+	// The result is just the list of imports, not the whole package payload.
+	imports, ok := out.([]string)
+	require.True(t, ok, "expected []string, got %T", out)
+	assert.Equal(t, []string{"fmt", "strings"}, imports)
 }
 
 func TestInvoke_GetSearch(t *testing.T) {
@@ -78,7 +79,7 @@ func TestInvoke_Symbol_RequiresSymbol(t *testing.T) {
 	d := newDispatcher(t, func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("client must not be called when the symbol argument is missing")
 	})
-	_, err := d.Invoke(context.Background(), "symbol", map[string]any{
+	_, err := d.Invoke(context.Background(), "symbol-doc", map[string]any{
 		"path": "github.com/samber/lo",
 	})
 	require.Error(t, err)
@@ -135,6 +136,59 @@ func TestInvoke_PackageExamples_BySymbol(t *testing.T) {
 	require.NoError(t, err)
 
 	// The result is the symbol's examples (a slice), not the whole docs string.
+	examples, ok := out.([]pkggodev.Example)
+	require.True(t, ok, "expected []pkggodev.Example, got %T", out)
+	require.NotEmpty(t, examples)
+	assert.Contains(t, examples[0].Code, "Foo(2)")
+}
+
+func TestInvoke_SymbolDoc(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasPrefix(r.URL.Path, "/v1beta/package/"), r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]any{
+			"path": "demo/pkg",
+			"name": "demo",
+			"docs": packageDocFixture(),
+		})
+		_, _ = w.Write(body)
+	})
+
+	out, err := d.Invoke(context.Background(), "symbol-doc", map[string]any{
+		"path":   "demo/pkg",
+		"symbol": "Foo",
+	})
+	require.NoError(t, err)
+
+	// symbol doc returns the full symbol (signature + doc), without examples.
+	sym, ok := out.(*pkggodev.Symbol)
+	require.True(t, ok, "expected *pkggodev.Symbol, got %T", out)
+	assert.Equal(t, "Foo", sym.Name)
+	assert.Contains(t, sym.Signature, "func Foo")
+	assert.Empty(t, sym.Examples, "symbol doc must not include examples")
+}
+
+func TestInvoke_SymbolExamples(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.True(t, strings.HasPrefix(r.URL.Path, "/v1beta/package/"), r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]any{
+			"path": "demo/pkg",
+			"name": "demo",
+			"docs": packageDocFixture(),
+		})
+		_, _ = w.Write(body)
+	})
+
+	out, err := d.Invoke(context.Background(), "symbol-examples", map[string]any{
+		"path":   "demo/pkg",
+		"symbol": "Foo",
+	})
+	require.NoError(t, err)
+
+	// symbol examples returns just the symbol's examples (a slice).
 	examples, ok := out.([]pkggodev.Example)
 	require.True(t, ok, "expected []pkggodev.Example, got %T", out)
 	require.NotEmpty(t, examples)

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -57,19 +57,48 @@ func TestInvoke_PackageImports(t *testing.T) {
 	assert.Equal(t, []string{"fmt", "strings"}, imports)
 }
 
+func TestInvoke_PackageInfo_ProjectsMetadataOnly(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1beta/package/github.com/samber/lo", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		// API returns heavy fields too; package info must not leak them.
+		_, _ = w.Write([]byte(`{"path":"github.com/samber/lo","name":"lo","version":"v1.2.3",` +
+			`"docs":"# huge docs","imports":["fmt"],"licenses":[{"types":["MIT"]}]}`))
+	})
+
+	out, err := d.Invoke(context.Background(), "package-info", map[string]any{
+		"path": "github.com/samber/lo",
+	})
+	require.NoError(t, err)
+
+	// Allow-list projection: only metadata fields, no docs/imports/licenses.
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"name":"lo"`)
+	assert.Contains(t, s, `"version":"v1.2.3"`)
+	assert.NotContains(t, s, "docs")
+	assert.NotContains(t, s, "imports")
+	assert.NotContains(t, s, "licenses")
+}
+
 func TestInvoke_GetSearch(t *testing.T) {
 	t.Parallel()
 	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1beta/search", r.URL.Path)
 		assert.Equal(t, "slice", r.URL.Query().Get("q"))
 		assert.Equal(t, "5", r.URL.Query().Get("limit"))
+		// search is the only operation that forwards --symbol as a query filter.
+		assert.Equal(t, "Map", r.URL.Query().Get("symbol"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"results":[]}`))
 	})
 
 	_, err := d.Invoke(context.Background(), "search", map[string]any{
-		"query": "slice",
-		"limit": float64(5), // MCP delivers numbers as float64
+		"query":  "slice",
+		"symbol": "Map",
+		"limit":  float64(5), // MCP delivers numbers as float64
 	})
 	require.NoError(t, err)
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -21,6 +21,7 @@ const (
 const (
 	groupPackage = "package"
 	groupModule  = "module"
+	groupSymbol  = "symbol"
 )
 
 // Param describes one optional query parameter of an operation.
@@ -70,9 +71,11 @@ const (
 func GroupShort(group string) string {
 	switch group {
 	case groupPackage:
-		return "Inspect a package (info, examples, licenses, doc)"
+		return "Inspect a package (info, imports, examples, licenses, doc)"
 	case groupModule:
 		return "Inspect a module (info, licenses, readme)"
+	case groupSymbol:
+		return "Inspect a single exported symbol (doc, examples)"
 	default:
 		return group
 	}
@@ -109,10 +112,15 @@ var Operations = []Operation{
 		Short:   "Go package metadata (name, synopsis, latest version, module).",
 		Arg:     argName,
 		ArgDesc: argDesc,
-		Params: []Param{
-			pModule, pVersion,
-			{"imports", Bool, "Include the packages this one imports"},
-		},
+		Params:  []Param{pModule, pVersion},
+	},
+	{
+		Group:   groupPackage,
+		Name:    "imports",
+		Short:   "List the packages that a Go package imports.",
+		Arg:     argName,
+		ArgDesc: argDesc,
+		Params:  []Param{pModule, pVersion},
 	},
 	{
 		Group:   groupPackage,
@@ -207,17 +215,26 @@ var Operations = []Operation{
 		ArgDesc: argDesc,
 		Params:  []Param{pModule, pVersion, pGOOS, pGOARCH, pLimit, pFilter},
 	},
+	// symbol subcommands
 	{
-		Name:     "symbol",
+		Group:    groupSymbol,
+		Name:     "doc",
 		Short:    "Documentation for a single exported symbol (signature + doc). Token-efficient vs package doc.",
 		Arg:      argName,
 		ArgDesc:  argDesc,
 		Arg2:     paramSymbol,
 		Arg2Desc: "Exported symbol, e.g. 'Map' or 'Type.Method'",
-		Params: []Param{
-			pModule, pVersion, pGOOS, pGOARCH,
-			{"examples", Bool, "Include runnable examples for the symbol"},
-		},
+		Params:   []Param{pModule, pVersion, pGOOS, pGOARCH},
+	},
+	{
+		Group:    groupSymbol,
+		Name:     "examples",
+		Short:    "Runnable examples for a single exported symbol. Token-efficient vs package examples.",
+		Arg:      argName,
+		ArgDesc:  argDesc,
+		Arg2:     paramSymbol,
+		Arg2Desc: "Exported symbol, e.g. 'Map' or 'Type.Method'",
+		Params:   []Param{pModule, pVersion, pGOOS, pGOARCH},
 	},
 	{
 		Name:    "vulns",


### PR DESCRIPTION
## Summary

Aligns the command tree on the per-facet pattern already used by the `package` group, and upgrades the pkg.go.dev client.

- **`symbol` → group**: `symbol doc <path> <symbol>` (signature + doc) and `symbol examples <path> <symbol>` (runnable examples). Replaces the old `symbol <path> <symbol> [--examples]`.
- **`package imports`**: new `package imports <path>` returning the import list, replacing the `--imports` flag on `package info`.
- **Dependency**: `go-pkggodev-client` v0.2.0 → v0.3.0.

Both the CLI and the MCP server are generated from `internal/spec`, so the MCP tools follow automatically:
- `symbol` → `symbol-doc` + `symbol-examples`
- `package-imports` replaces the `imports` flag on `package-info`

`WithDoc` is a no-op on the client's `Symbol()` call (it always parses markdown since v0.3.0), so it was dropped from the symbol example routes.

## Breaking changes

- `godig symbol <path> <symbol>` and the `--examples` / `--imports` flags are removed → use `symbol doc` / `symbol examples` / `package imports`.
- MCP tool `symbol` is replaced by `symbol-doc` and `symbol-examples`.

## Tests

`go build ./... && go vet ./... && go test ./...` — all green.
