### PR TITLE
Align CLI/MCP: positional arg help + compact MCP JSON

### DIFF
--- a/cmd/godig/commands.go
+++ b/cmd/godig/commands.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/samber/godig/internal/spec"
 	"github.com/spf13/cobra"
 )
@@ -58,6 +61,7 @@ func buildCommand(op spec.Operation) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   use,
 		Short: op.Short,
+		Long:  longHelp(op),
 		Args:  argsOrHelp(argsRule),
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
 			return runOperation(cmd, op.Key(), args, posArgs)
@@ -76,4 +80,23 @@ func buildCommand(op spec.Operation) *cobra.Command {
 	}
 
 	return cmd
+}
+
+// longHelp augments the short description with a description of each positional
+// argument. Cobra's usage line only shows argument names (<path> <symbol>), so
+// without this the spec's ArgDesc/Arg2Desc — surfaced by the MCP tool schema —
+// would be lost in the CLI help. Returns "" (cobra falls back to Short) when the
+// operation takes no positional argument.
+func longHelp(op spec.Operation) string {
+	if op.Arg == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(op.Short)
+	b.WriteString("\n\nArguments:\n")
+	fmt.Fprintf(&b, "  %-8s %s\n", op.Arg, op.ArgDesc)
+	if op.Arg2 != "" {
+		fmt.Fprintf(&b, "  %-8s %s\n", op.Arg2, op.Arg2Desc)
+	}
+	return b.String()
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -46,7 +46,7 @@ func (h *handler) handle(opID string) server.ToolHandlerFunc {
 			slog.Error("mcp tool failed", "tool", opID, "err", err)
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		b, err := json.MarshalIndent(out, "", "  ")
+		b, err := json.Marshal(out)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}


### PR DESCRIPTION
Two divergences found between the CLI and MCP APIs (both are driven by the same `internal/spec` catalog and `internal/dispatch`, so the divergences were in wiring/rendering, not in the operation set).

## Changes

**fix(cli): surface positional argument descriptions in help**
The spec defines `ArgDesc`/`Arg2Desc` for positional arguments (e.g. `path` and `symbol`). The MCP tool schema exposes these, but the CLI dropped them — cobra's usage line only shows argument names (`<path> <symbol>`). They are now rendered in the command `Long` help, restoring documentation parity.

**perf(mcp): emit compact JSON in tool results**
`server.go` switched from `json.MarshalIndent` to `json.Marshal`, so MCP tool responses no longer carry indentation and newlines — fewer tokens for MCP clients. The CLI is unaffected (it has its own renderer; `-o json` still pretty-prints).

## Testing
`go build ./...` and `go test ./...` pass (including the end-to-end `tests/` MCP suite).
