### PR TITLE
fix: code-review follow-ups (architecture, CI, code quality)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,7 @@ name: Security scan
 on:
   push:
     branches:
-      - maser
+      - main
   pull_request:
   schedule:
     - cron: '0 3 * * 1'
@@ -15,22 +15,22 @@ permissions:
   security-events: write
 
 jobs:
-  # govulncheck:
-  #   name: govulncheck
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - uses: actions/setup-go@v6
-  #       with:
-  #         go-version-file: go.mod
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-  #     - name: Install govulncheck
-  #       run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-  #     - name: govulncheck
-  #       run: govulncheck ./...
+      - name: govulncheck
+        run: govulncheck ./...
 
   bearer:
     name: bearer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/cmd/godig/root.go
+++ b/cmd/godig/root.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	pkggodev "github.com/samber/go-pkggodev-client"
@@ -42,8 +41,9 @@ func Execute() {
 // run executes the root command and returns the process exit code.
 func run() int {
 	// Cancel in-flight work (e.g. an HTTP request to pkg.go.dev) on Ctrl-C or
-	// SIGTERM instead of blocking until the request timeout elapses.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	// SIGTERM instead of blocking until the request timeout elapses. The signal
+	// set is platform-specific (see signals_unix.go / signals_windows.go).
+	ctx, stop := signal.NotifyContext(context.Background(), shutdownSignals...)
 	defer stop()
 
 	err := rootCmd.ExecuteContext(ctx)

--- a/cmd/godig/root.go
+++ b/cmd/godig/root.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	pkggodev "github.com/samber/go-pkggodev-client"
@@ -28,18 +31,31 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// Execute runs the root command. Called by main.
+// Execute runs the root command. Called by main. It is split from run so the
+// signal-context cleanup (defer) runs before the process exits.
 func Execute() {
-	err := rootCmd.Execute()
+	if code := run(); code != 0 {
+		os.Exit(code)
+	}
+}
+
+// run executes the root command and returns the process exit code.
+func run() int {
+	// Cancel in-flight work (e.g. an HTTP request to pkg.go.dev) on Ctrl-C or
+	// SIGTERM instead of blocking until the request timeout elapses.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	err := rootCmd.ExecuteContext(ctx)
 	if err == nil {
-		return
+		return 0
 	}
 	// Invalid args/flags already printed the full help (see argsOrHelp); exit cleanly.
 	if errors.Is(err, errHelpShown) {
-		return
+		return 0
 	}
 	fmt.Fprintln(os.Stderr, "godig:", err)
-	os.Exit(1)
+	return 1
 }
 
 func init() {

--- a/cmd/godig/run.go
+++ b/cmd/godig/run.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/samber/godig/internal/render"
@@ -39,7 +38,7 @@ func runOperation(cmd *cobra.Command, name string, pathParams, args []string) er
 	if err != nil {
 		return err
 	}
-	out, err := d.Invoke(context.Background(), name, m)
+	out, err := d.Invoke(cmd.Context(), name, m)
 	if err != nil {
 		slog.Error("command failed", "command", name, "err", err)
 		return err

--- a/cmd/godig/signals_unix.go
+++ b/cmd/godig/signals_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// shutdownSignals are the OS signals that trigger graceful cancellation.
+// On Unix-like systems this includes SIGTERM (sent by init systems, Docker,
+// Kubernetes, etc.) in addition to SIGINT (Ctrl-C).
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/cmd/godig/signals_windows.go
+++ b/cmd/godig/signals_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// shutdownSignals are the OS signals that trigger graceful cancellation.
+// Windows does not deliver SIGTERM to console applications; os.Interrupt
+// (Ctrl-C / Ctrl-Break) is the only portable shutdown signal there.
+var shutdownSignals = []os.Signal{os.Interrupt}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -54,13 +54,23 @@ func friendlyError(err error, name, path, version string) error {
 		if version != "" {
 			target += "@" + version
 		}
-		return fmt.Errorf("not found: %s", target)
+		return &apiError{msg: "not found: " + target, err: err}
 	}
 	if msg := apiMessage(status.Payload); msg != "" {
-		return fmt.Errorf("pkg.go.dev: %s (HTTP %d)", msg, status.StatusCode)
+		return &apiError{msg: fmt.Sprintf("pkg.go.dev: %s (HTTP %d)", msg, status.StatusCode), err: err}
 	}
-	return fmt.Errorf("pkg.go.dev returned HTTP %d", status.StatusCode)
+	return &apiError{msg: fmt.Sprintf("pkg.go.dev returned HTTP %d", status.StatusCode), err: err}
 }
+
+// apiError carries a human-friendly message for display while preserving the
+// underlying client error, so callers can still inspect it with errors.Is/As.
+type apiError struct {
+	msg string
+	err error
+}
+
+func (e *apiError) Error() string { return e.msg }
+func (e *apiError) Unwrap() error { return e.err }
 
 // apiMessage extracts the pkg.go.dev error message from a buffered error
 // response body (the ogen client retains it), returning "" if unavailable.
@@ -330,7 +340,7 @@ type Overview struct {
 
 // overview composes package + module + versions + vulns into one compact result.
 // The package lookup is authoritative (its error, e.g. 404, is returned); the
-// secondary lookups are best-effort and silently skipped on error.
+// secondary lookups are best-effort and skipped (logged at debug) on error.
 func (d *Dispatcher) overview(ctx context.Context, path string, opts []pkggodev.Option) (any, error) {
 	pkg, err := d.c.Package(ctx, path, append(opts, pkggodev.WithLicenses())...)
 	if err != nil {
@@ -354,16 +364,22 @@ func (d *Dispatcher) overview(ctx context.Context, path string, opts []pkggodev.
 		if mod.Version != "" {
 			ov.LatestVersion = mod.Version
 		}
+	} else {
+		slog.Debug("overview: module lookup skipped", "module", modulePath, "err", e)
 	}
 	if page, e := d.c.Versions(ctx, modulePath, pkggodev.WithLimit(10)); e == nil {
 		for _, v := range page.Items {
 			ov.RecentVersions = append(ov.RecentVersions, v.Version)
 		}
+	} else {
+		slog.Debug("overview: versions lookup skipped", "module", modulePath, "err", e)
 	}
 	if page, e := d.c.Vulns(ctx, path); e == nil {
 		for _, v := range page.Items {
 			ov.Vulnerabilities = append(ov.Vulnerabilities, v.ID)
 		}
+	} else {
+		slog.Debug("overview: vulns lookup skipped", "path", path, "err", e)
 	}
 	return ov, nil
 }
@@ -448,14 +464,29 @@ func optionsFrom(a map[string]any) []pkggodev.Option {
 // --- argument coercion helpers (tolerate CLI strings and MCP JSON types) ---
 
 func str(a map[string]any, key string) string {
-	v, ok := a[key]
-	if !ok || v == nil {
+	switch v := a[key].(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	case float64:
+		// JSON numbers decode as float64; render whole numbers without a
+		// fractional part (e.g. a version passed as 2 instead of "2").
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'g', -1, 64)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	default:
+		// Unexpected composite type for a string field: avoid leaking a Go-syntax
+		// representation (fmt.Sprint) into an API path/query.
 		return ""
 	}
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return fmt.Sprint(v)
 }
 
 func intOf(a map[string]any, key string) int {

--- a/internal/dispatch/routes_test.go
+++ b/internal/dispatch/routes_test.go
@@ -1,0 +1,56 @@
+package dispatch_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pkggodev "github.com/samber/go-pkggodev-client"
+	"github.com/samber/godig/internal/dispatch"
+	"github.com/samber/godig/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvoke_EveryOperationRoutes guards against spec/dispatch drift: every
+// operation in the hand-written catalog must be routable by the dispatcher.
+// A catalog entry with no matching dispatch case would still compile and
+// register a CLI command and an MCP tool, then fail only at call time with
+// "unknown operation". Other errors (e.g. decode failures against the stub
+// server) are irrelevant here — we assert solely that routing resolves.
+func TestInvoke_EveryOperationRoutes(t *testing.T) {
+	t.Parallel()
+
+	empty := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}
+	api := httptest.NewServer(http.HandlerFunc(empty))
+	t.Cleanup(api.Close)
+	// major-versions probes the Go module proxy directly (not the API base URL);
+	// point it at a stub too so the test never reaches the network.
+	proxy := httptest.NewServer(http.HandlerFunc(empty))
+	t.Cleanup(proxy.Close)
+
+	c, err := pkggodev.New(
+		pkggodev.WithBaseURL(api.URL+"/v1beta"),
+		pkggodev.WithGoproxy(proxy.URL),
+	)
+	require.NoError(t, err)
+	d := dispatch.New(c)
+
+	for _, op := range spec.Operations {
+		t.Run(op.Key(), func(t *testing.T) {
+			t.Parallel()
+			// Provide every required positional so routing is reached for ops
+			// that validate args before dispatching (search, symbol-*).
+			args := map[string]any{"path": "example.com/x", "query": "x", "symbol": "X"}
+			_, err := d.Invoke(context.Background(), op.Key(), args)
+			if err != nil {
+				assert.NotContains(t, err.Error(), "unknown operation",
+					"operation %q is in the catalog but has no dispatch route", op.Key())
+			}
+		})
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -42,14 +42,25 @@ func Write(w io.Writer, v any, format string) error {
 	}
 }
 
-// writeTable normalises v through JSON and renders the most table-like view.
-func writeTable(w io.Writer, v any) error {
+// toGeneric normalises any typed value into the generic JSON shape
+// (map[string]any / []any / scalar) that the table and markdown renderers
+// introspect.
+func toGeneric(v any) (any, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var generic any
 	if err := json.Unmarshal(b, &generic); err != nil {
+		return nil, err
+	}
+	return generic, nil
+}
+
+// writeTable normalises v through JSON and renders the most table-like view.
+func writeTable(w io.Writer, v any) error {
+	generic, err := toGeneric(v)
+	if err != nil {
 		return err
 	}
 
@@ -149,12 +160,8 @@ func sortedKeys(m map[string]any) []string {
 // objects, a bullet list for a list of scalars, a key/value table for an
 // object, and a fenced JSON block as a fallback.
 func markdown(v any) string {
-	b, err := json.Marshal(v)
+	generic, err := toGeneric(v)
 	if err != nil {
-		return ""
-	}
-	var generic any
-	if err := json.Unmarshal(b, &generic); err != nil {
 		return ""
 	}
 


### PR DESCRIPTION
Follow-up fixes from the deep code review, scoped to architecture attention points, the security-CI item, and code-quality items 1–4.

## Architecture
- **Signal-aware cancellation.** `Execute` now builds a `signal.NotifyContext` (SIGINT/SIGTERM) and runs via `ExecuteContext`; `runOperation` uses `cmd.Context()`. Ctrl-C now cancels an in-flight pkg.go.dev request instead of waiting out the HTTP timeout. Split into `Execute`/`run` so the context cleanup `defer` runs before `os.Exit`.
- **Spec↔dispatch drift guard.** New `internal/dispatch/routes_test.go` iterates `spec.Operations` and asserts every catalog entry resolves to a dispatch route (catches a spec-only addition that would otherwise fail at call time with `unknown operation`). Uses local stub servers for both the API base URL and the Go module proxy — no network.

## Security / CI
- **Workflow branch triggers.** `security.yml` triggered on a misspelled `maser` branch and `test.yml` on `master`, while the default branch is `main` → neither ran on push to `main`. Both now target `main`.
- **Re-enabled `govulncheck`** in the security workflow (was fully commented out).

## Code quality
1. **Error chain preserved.** `friendlyError` returns an `apiError` (friendly `Error()` message + `Unwrap()`), so callers keep a clean display string *and* a working `errors.Is/As` chain.
2. **`overview` diagnostics.** Best-effort module/versions/vulns lookups are now logged at `slog.Debug` when skipped, instead of dropped silently.
3. **`render.toGeneric` helper.** Removes the duplicated `json.Marshal`→`Unmarshal` round-trip shared by `writeTable` and `markdown`.
4. **Safer `str()`.** Handles JSON scalars (string/bool/float64/int) explicitly and returns `""` for unexpected composite types rather than leaking a Go-syntax representation (`fmt.Sprint`) into an API path/query.

## Validation
- `go build ./...`, `go vet ./...` clean
- `golangci-lint run` → 0 issues
- `go test -race ./...` green (unit + integration suite that drives the built binary)