### PR TITLE
feat: dependencies command, module size and min Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ godig symbol doc github.com/samber/ro Map
 godig symbol examples github.com/samber/mo Either.ForEach
 
 # Module facets
-godig module info github.com/samber/ro
+godig module info github.com/samber/ro            # incl. download size + min Go version
 godig module readme github.com/samber/ro
 godig module licenses github.com/samber/ro
+godig dependencies github.com/samber/oops         # go.mod requires/replaces/excludes
 
 # Lists (auto-paginated; --limit to cap, -o md for a Markdown table)
 godig versions github.com/samber/ro -o md
@@ -91,9 +92,10 @@ All flags can also be set via `GODIG_`-prefixed environment variables.
 | `godig package licenses <path>`           | Package licenses                     |
 | `godig symbol doc <path> <symbol>`        | One symbol's signature + doc         |
 | `godig symbol examples <path> <symbol>`   | One symbol's runnable examples       |
-| `godig module info <path>`                | Module metadata                      |
+| `godig module info <path>`                | Module metadata (incl. size + min Go version) |
 | `godig module licenses <path>`            | Module licenses                      |
 | `godig module readme <path>`              | Module README                        |
+| `godig dependencies <module>`             | Module dependencies from its go.mod  |
 | `godig packages <module>`                 | List a module's packages             |
 | `godig versions <module>`                 | List module versions                 |
 | `godig major-versions <module>`           | List major versions (v1, v2, v3 ...) |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/ogen-go/ogen v1.22.0
-	github.com/samber/go-pkggodev-client v0.3.0
+	github.com/samber/go-pkggodev-client v0.4.0
 	github.com/samber/hot v0.13.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -42,6 +42,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/samber/go-singleflightx v0.3.2 // indirect
+	github.com/samber/mo v1.17.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,10 +77,14 @@ github.com/samber/go-pkggodev-client v0.2.0 h1:tcToCfDbx+7kN0aPB6eu0FzMAveYrmCss
 github.com/samber/go-pkggodev-client v0.2.0/go.mod h1:OLRvaNGSIOJ7NncJrConRUBI/DK+NvllB2s3B37SBDY=
 github.com/samber/go-pkggodev-client v0.3.0 h1:nrgVSXtvd6H5y09eKFrup8BQKL6S2YzxgRohzXsCfdA=
 github.com/samber/go-pkggodev-client v0.3.0/go.mod h1:tQKn0VDMRjTWCisR5uRX+wxZFkBs4jVkRIykApoyKpk=
+github.com/samber/go-pkggodev-client v0.4.0 h1:ZGd8grqIZLTlHFkXriYvRSD33FPDxgIl1eX8tv/acNE=
+github.com/samber/go-pkggodev-client v0.4.0/go.mod h1:l0fsUGEDAavNh7CDiqfhzxrjx3dtXmbhCYqGAO14LQ4=
 github.com/samber/go-singleflightx v0.3.2 h1:jXbUU0fvis8Fdv4HGONboX5WdEZcYLoBEcKiE+ITCyQ=
 github.com/samber/go-singleflightx v0.3.2/go.mod h1:X2BR+oheHIYc73PvxRMlcASg6KYYTQyUYpdVU7t/ux4=
 github.com/samber/hot v0.13.0 h1:4/OyD5xNfhmdHqyKWHHSisiytp93gA3knkWZLAvld2w=
 github.com/samber/hot v0.13.0/go.mod h1:NB9v5U4NfDx7jmlrP+zHuqCuLUsywgAtCH7XOAkOxAg=
+github.com/samber/mo v1.17.0 h1:EbeLc7nxIdpalstxQQakLOcXxULuMRqo7PJPtY18bQg=
+github.com/samber/mo v1.17.0/go.mod h1:DlgzJ4SYhOh41nP1L9kh9rDNERuf8IqWSAs+gj2Vxag=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -94,7 +94,6 @@ func apiMessage(resp *http.Response) string {
 func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (any, error) {
 	path := str(a, "path")
 	opts := optionsFrom(a)
-	limit := intOf(a, "limit")
 	slog.Info("invoking operation", "operation", name, "path", path, "options", len(opts))
 
 	if strings.HasPrefix(name, "package-") {
@@ -106,10 +105,15 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 	if strings.HasPrefix(name, "symbol-") {
 		return d.routeSymbol(ctx, name, path, a, opts)
 	}
+	return d.routeTopLevel(ctx, name, path, a, opts)
+}
 
-	// Listing operations auto-paginate (AllX) and return the full slice of items,
-	// so the table output shows rows and never a nextToken cursor. --limit caps
-	// the total number of items returned.
+// routeTopLevel handles the ungrouped operations (overview, search, the listing
+// commands, dependencies). Listing operations auto-paginate (AllX) and return
+// the full slice of items, so the table output shows rows and never a nextToken
+// cursor. --limit caps the total number of items returned.
+func (d *Dispatcher) routeTopLevel(ctx context.Context, name, path string, a map[string]any, opts []pkggodev.Option) (any, error) {
+	limit := intOf(a, "limit")
 	switch name {
 	case "overview":
 		return d.overview(ctx, path, opts)
@@ -135,6 +139,8 @@ func (d *Dispatcher) route(ctx context.Context, name string, a map[string]any) (
 		return collectN(d.c.AllVersions(ctx, path, opts...), limit)
 	case "major-versions":
 		return d.majorVersions(ctx, path, opts)
+	case "dependencies":
+		return d.c.Dependencies(ctx, path, opts...)
 	case "symbols":
 		return collectN(d.c.AllSymbols(ctx, path, opts...), limit)
 	case "vulns":
@@ -164,12 +170,12 @@ type PackageInfo struct {
 func newPackageInfo(p *pkggodev.Package) PackageInfo {
 	return PackageInfo{
 		Path:              p.Path,
-		ModulePath:        p.ModulePath,
-		Name:              p.Name,
-		Synopsis:          p.Synopsis,
-		Version:           p.Version,
-		Goos:              p.Goos,
-		Goarch:            p.Goarch,
+		ModulePath:        p.ModulePath.OrEmpty(),
+		Name:              p.Name.OrEmpty(),
+		Synopsis:          p.Synopsis.OrEmpty(),
+		Version:           p.Version.OrEmpty(),
+		Goos:              p.Goos.OrEmpty(),
+		Goarch:            p.Goarch.OrEmpty(),
 		IsLatest:          p.IsLatest,
 		IsRedistributable: p.IsRedistributable,
 		IsStandardLibrary: p.IsStandardLibrary,
@@ -205,7 +211,7 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		if err != nil {
 			return nil, err
 		}
-		return p.Docs, nil
+		return p.Docs.OrEmpty(), nil
 	case "package-examples":
 		// Scoped to a single symbol when --symbol is given: return just that
 		// symbol's examples instead of the whole (large) package examples blob.
@@ -217,7 +223,7 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 		if err != nil {
 			return nil, err
 		}
-		return p.Docs, nil
+		return p.Docs.OrEmpty(), nil
 	case "package-licenses":
 		p, err := d.c.Package(ctx, path, append(opts, pkggodev.WithLicenses())...)
 		if err != nil {
@@ -230,12 +236,16 @@ func (d *Dispatcher) routePackage(ctx context.Context, name, path string, a map[
 }
 
 // ModuleInfo is the metadata-only projection returned by `module info`.
-// See PackageInfo for the allow-list rationale.
+// See PackageInfo for the allow-list rationale. GoVersion is the module's "go"
+// directive (its minimum Go version) and Size is the module zip's download size
+// in bytes (proxy HEAD request); Size is omitted when no module proxy is usable.
 type ModuleInfo struct {
 	Path              string    `json:"path"`
 	Version           string    `json:"version,omitempty"`
+	GoVersion         string    `json:"goVersion,omitempty"`
 	RepoURL           string    `json:"repoUrl,omitempty"`
 	CommitTime        time.Time `json:"commitTime,omitzero"`
+	Size              int64     `json:"size,omitempty"`
 	HasGoMod          bool      `json:"hasGoMod"`
 	IsLatest          bool      `json:"isLatest"`
 	IsRedistributable bool      `json:"isRedistributable"`
@@ -245,9 +255,11 @@ type ModuleInfo struct {
 func newModuleInfo(m *pkggodev.Module) ModuleInfo {
 	return ModuleInfo{
 		Path:              m.Path,
-		Version:           m.Version,
-		RepoURL:           m.RepoURL,
-		CommitTime:        m.CommitTime,
+		Version:           m.Version.OrEmpty(),
+		GoVersion:         m.GoVersion.OrEmpty(),
+		RepoURL:           m.RepoURL.OrEmpty(),
+		CommitTime:        m.CommitTime.OrEmpty(),
+		Size:              m.Size.OrEmpty(),
 		HasGoMod:          m.HasGoMod,
 		IsLatest:          m.IsLatest,
 		IsRedistributable: m.IsRedistributable,
@@ -259,11 +271,30 @@ func newModuleInfo(m *pkggodev.Module) ModuleInfo {
 func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []pkggodev.Option) (any, error) {
 	switch name {
 	case "module-info":
-		m, err := d.c.Module(ctx, path, opts...)
+		// WithSize adds the module zip download size (one proxy HEAD request).
+		// Fall back to a size-less lookup when no proxy is usable so `module
+		// info` still works with GOPROXY=off (it then omits the size field).
+		m, err := d.c.Module(ctx, path, append(opts, pkggodev.WithSize())...)
+		if errors.Is(err, pkggodev.ErrProxyDisabled) {
+			slog.Debug("module info: size skipped, proxy disabled", "module", path)
+			m, err = d.c.Module(ctx, path, opts...)
+		}
 		if err != nil {
 			return nil, err
 		}
-		return newModuleInfo(m), nil
+		info := newModuleInfo(m)
+		// pkg.go.dev doesn't return the go.mod, so the "go" directive (the
+		// module's minimum Go version) is absent from the API response.
+		// Backfill it best-effort from the module proxy's go.mod — the same
+		// source as `dependencies` — skipping silently when no proxy is usable.
+		if info.GoVersion == "" {
+			if deps, e := d.c.Dependencies(ctx, path, opts...); e == nil {
+				info.GoVersion = deps.GoVersion.OrEmpty()
+			} else {
+				slog.Debug("module info: goVersion backfill skipped", "module", path, "err", e)
+			}
+		}
+		return info, nil
 	case "module-licenses":
 		m, err := d.c.Module(ctx, path, append(opts, pkggodev.WithLicenses())...)
 		if err != nil {
@@ -275,7 +306,7 @@ func (d *Dispatcher) routeModule(ctx context.Context, name, path string, opts []
 		if err != nil {
 			return nil, err
 		}
-		return m.Readme.Contents, nil
+		return m.Readme.OrEmpty().Contents.OrEmpty(), nil
 	default:
 		return nil, fmt.Errorf("unknown operation %q", name)
 	}
@@ -346,23 +377,23 @@ func (d *Dispatcher) overview(ctx context.Context, path string, opts []pkggodev.
 	if err != nil {
 		return nil, err
 	}
-	modulePath := pkg.ModulePath
+	modulePath := pkg.ModulePath.OrEmpty()
 	if modulePath == "" {
 		modulePath = path
 	}
 	ov := &Overview{
 		Path:              path,
-		Name:              pkg.Name,
-		Synopsis:          pkg.Synopsis,
+		Name:              pkg.Name.OrEmpty(),
+		Synopsis:          pkg.Synopsis.OrEmpty(),
 		ModulePath:        modulePath,
 		IsStandardLibrary: pkg.IsStandardLibrary,
-		LatestVersion:     pkg.Version,
+		LatestVersion:     pkg.Version.OrEmpty(),
 		Licenses:          licenseTypes(pkg.Licenses),
 	}
 	if mod, e := d.c.Module(ctx, modulePath); e == nil {
-		ov.RepoURL = mod.RepoURL
-		if mod.Version != "" {
-			ov.LatestVersion = mod.Version
+		ov.RepoURL = mod.RepoURL.OrEmpty()
+		if v, ok := mod.Version.Get(); ok {
+			ov.LatestVersion = v
 		}
 	} else {
 		slog.Debug("overview: module lookup skipped", "module", modulePath, "err", e)

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -38,6 +38,20 @@ func newDispatcherWithProxy(t *testing.T, proxy http.HandlerFunc) *dispatch.Disp
 	return dispatch.New(c)
 }
 
+// newDispatcherAPIAndProxy wires both a mock pkg.go.dev API and a mock Go module
+// proxy, needed by operations that combine the two (e.g. `module info` with
+// WithSize: module metadata from the API, zip size from the proxy).
+func newDispatcherAPIAndProxy(t *testing.T, api, proxy http.HandlerFunc) *dispatch.Dispatcher {
+	t.Helper()
+	asrv := httptest.NewServer(api)
+	t.Cleanup(asrv.Close)
+	psrv := httptest.NewServer(proxy)
+	t.Cleanup(psrv.Close)
+	c, err := pkggodev.New(pkggodev.WithBaseURL(asrv.URL+"/v1beta"), pkggodev.WithGoproxy(psrv.URL))
+	require.NoError(t, err)
+	return dispatch.New(c)
+}
+
 func TestInvoke_PackageImports(t *testing.T) {
 	t.Parallel()
 	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
@@ -249,6 +263,129 @@ func TestInvoke_MajorVersions(t *testing.T) {
 	assert.Contains(t, string(b), "github.com/samber/do/v2")
 	assert.Contains(t, string(b), `"major":"v2"`)
 	assert.Contains(t, string(b), `"major":"v1"`)
+}
+
+func TestInvoke_ModuleInfo_SizeAndGoVersion(t *testing.T) {
+	t.Parallel()
+	d := newDispatcherAPIAndProxy(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/v1beta/module/github.com/samber/lo", r.URL.Path)
+			// WithSize must be requested at the proxy, not the API.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"path":"github.com/samber/lo","version":"v1.2.3",`+
+				`"goModContents":"module github.com/samber/lo\n\ngo 1.21\n","hasGoMod":true}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			// Size comes from a HEAD on the module zip's Content-Length.
+			assert.Equal(t, http.MethodHead, r.Method)
+			assert.True(t, strings.HasSuffix(r.URL.Path, "/github.com/samber/lo/@v/v1.2.3.zip"), r.URL.Path)
+			w.Header().Set("Content-Length", "4096")
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+
+	out, err := d.Invoke(context.Background(), "module-info", map[string]any{
+		"path": "github.com/samber/lo",
+	})
+	require.NoError(t, err)
+
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"goVersion":"1.21"`)
+	assert.Contains(t, s, `"size":4096`)
+}
+
+// TestInvoke_ModuleInfo_SizeSkippedWithoutProxy verifies `module info` still
+// succeeds (omitting size) when no module proxy is usable, while goVersion —
+// derived from the go.mod the API returns — is still present.
+func TestInvoke_ModuleInfo_SizeSkippedWithoutProxy(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"path":"github.com/samber/lo","version":"v1.2.3",`+
+			`"goModContents":"module github.com/samber/lo\n\ngo 1.21\n","hasGoMod":true}`)
+	})
+
+	out, err := d.Invoke(context.Background(), "module-info", map[string]any{
+		"path": "github.com/samber/lo",
+	})
+	require.NoError(t, err)
+
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"goVersion":"1.21"`)
+	assert.NotContains(t, s, `"size"`)
+}
+
+// TestInvoke_ModuleInfo_GoVersionBackfill covers the common production case
+// where pkg.go.dev returns no go.mod: `module info` must backfill goVersion from
+// the module proxy's go.mod (the "go" directive).
+func TestInvoke_ModuleInfo_GoVersionBackfill(t *testing.T) {
+	t.Parallel()
+	goMod := "module github.com/samber/lo\n\ngo 1.18\n"
+	d := newDispatcherAPIAndProxy(t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			// No goModContents -> goVersion absent from the API response.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"path":"github.com/samber/lo","version":"v1.2.3","hasGoMod":true}`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/@v/v1.2.3.zip"):
+				w.Header().Set("Content-Length", "4096")
+				w.WriteHeader(http.StatusOK)
+			case strings.HasSuffix(r.URL.Path, "/github.com/samber/lo/@latest"):
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"Version":"v1.2.3"}`)
+			case strings.HasSuffix(r.URL.Path, "/github.com/samber/lo/@v/v1.2.3.mod"):
+				_, _ = io.WriteString(w, goMod)
+			default:
+				http.NotFound(w, r)
+			}
+		},
+	)
+
+	out, err := d.Invoke(context.Background(), "module-info", map[string]any{
+		"path": "github.com/samber/lo",
+	})
+	require.NoError(t, err)
+
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"goVersion":"1.18"`)
+}
+
+func TestInvoke_Dependencies(t *testing.T) {
+	t.Parallel()
+	goMod := "module github.com/samber/do\n\ngo 1.18\n\n" +
+		"require github.com/stretchr/testify v1.8.0\n\n" +
+		"require golang.org/x/sync v0.1.0 // indirect\n"
+	d := newDispatcherWithProxy(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/github.com/samber/do/@latest"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"Version":"v1.6.0"}`)
+		case strings.HasSuffix(r.URL.Path, "/github.com/samber/do/@v/v1.6.0.mod"):
+			_, _ = io.WriteString(w, goMod)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	out, err := d.Invoke(context.Background(), "dependencies", map[string]any{
+		"path": "github.com/samber/do",
+	})
+	require.NoError(t, err)
+
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"version":"v1.6.0"`)
+	assert.Contains(t, s, `"goVersion":"1.18"`)
+	assert.Contains(t, s, `github.com/stretchr/testify`)
+	assert.Contains(t, s, `"indirect":true`)
 }
 
 func TestInvoke_UnknownOperation(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -199,6 +199,13 @@ var Operations = []Operation{
 		Params:  []Param{pLimit, pFilter},
 	},
 	{
+		Name:    "dependencies",
+		Short:   "Export a Go module's dependencies from its go.mod (requires, replaces, excludes, go directive).",
+		Arg:     argName,
+		ArgDesc: argDesc,
+		Params:  []Param{pVersion},
+	},
+	{
 		Name:    "major-versions",
 		Short:   "List a Go module's major versions (v1, v2, v3 ...), which live as separate modules.",
 		Arg:     argName,


### PR DESCRIPTION
## Summary

Upgrades [`go-pkggodev-client`](https://github.com/samber/go-pkggodev-client) to **v0.4.0** and surfaces its new capabilities through the CLI and MCP server.

- **`dependencies <module>`** — new top-level command/tool that exports a module's `go.mod`: `requires` (with `// indirect`), `replaces`, `excludes` and the `go` directive, parsed from the Go module proxy.
- **`module info`** now includes:
  - **`size`** — the module zip download size in bytes (proxy `HEAD` request; falls back to a size-less lookup so it still works with `GOPROXY=off`).
  - **`goVersion`** — the module's minimum Go version. pkg.go.dev does not return the `go.mod`, so this is backfilled best-effort from the proxy's `go.mod` when absent from the API response.

## Client v0.4.0 adaptation

v0.4.0 moved many optional response fields to `mo.Option[T]`. The dispatch projections are updated accordingly (`.OrEmpty()` / `.Get()`). The top-level dispatch `switch` is extracted into `routeTopLevel` to keep cyclomatic complexity under the lint threshold.

## Tests

Added hermetic tests (httptest API + mock module proxy) for: `module info` size + goVersion (API-supplied and proxy-backfilled paths), the proxy-disabled fallback, and the `dependencies` command. Verified live against `samber/lo` and `samber/oops`.

`go build`, `go test ./...`, `go vet` and `golangci-lint` all pass.
