### PR TITLE
fix(cli): consistent exit codes, limit validation, dependency rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ godig dependencies github.com/samber/oops         # go.mod requires/replaces/exc
 # Lists (auto-paginated; --limit to cap, -o md for a Markdown table)
 godig versions github.com/samber/ro -o md
 godig major-versions github.com/samber/do        # v1, v2, v3 ... (separate modules)
+godig major-versions github.com/samber/do --exclude-pseudo   # drop majors whose latest is a pseudo-version
 godig packages github.com/samber/ro
 godig imported-by github.com/samber/ro --limit 20
 godig symbols github.com/samber/ro
@@ -78,6 +79,9 @@ godig mcp
 Global flags: `-o, --output` (`table` default, `json`, `raw`, `md`), `--base-url`, `--timeout`,
 `--log-level` (`debug|info|warn|error|off`, default `error`; logs go to **stderr**).
 All flags can also be set via `GODIG_`-prefixed environment variables.
+
+Exit codes: `0` success, `1` runtime error (e.g. network, package not found), `2` usage error
+(missing/invalid arguments or flags, or a group invoked without a subcommand).
 
 ## 🧠 Commands
 
@@ -105,11 +109,45 @@ All flags can also be set via `GODIG_`-prefixed environment variables.
 | `godig mcp`                               | Run the MCP server (stdio or http)   |
 
 Run `godig <command> --help` (or `godig package --help`) for per-command flags. Each operation is
-also exposed as an MCP tool (e.g. `overview`, `package-info`, `module-readme`).
+also exposed as an MCP tool (e.g. `overview`, `package-info`, `module-readme`). Utility commands:
+`godig version` and `godig completion <shell>` (bash/zsh/fish/powershell).
 
 **For AI agents (token-efficient):** start with `overview` — one call returns a compact summary
 (no large docs). Fetch `doc`, `examples`, `module readme` or `licenses` only when the full text is
 actually needed, and cap long lists (`versions`, `imported-by`) with `--limit`.
+
+## 🔎 Filters
+
+The `--filter` flag (on `search`, `versions`, `packages`, `imported-by`, `symbols`, `vulns`,
+`major-versions`) takes a **Go boolean expression** evaluated server-side over each item. The
+identifiers are the item's fields — which **differ per command**, so a field valid for one list is
+not valid for another (e.g. `search` exposes `packagePath`, not `path`). Helper functions include
+`hasPrefix`, `hasSuffix` and `contains`.
+
+```sh
+godig search "result option" --filter 'hasPrefix(packagePath, "github.com/samber/")'
+godig versions github.com/samber/ro --filter 'hasPrefix(version, "v0.3")'
+godig symbols github.com/samber/ro  --filter 'kind == "Function"'
+godig imported-by github.com/samber/ro --filter 'contains(path, "/internal/")'
+```
+
+Available fields per command (string unless noted):
+
+| Command          | Filterable fields                                                                 |
+| ---------------- | --------------------------------------------------------------------------------- |
+| `search`         | `modulePath`, `packagePath`, `synopsis`, `version`                                 |
+| `versions`       | `version`, `modulePath`, `deprecated` (bool), `retracted` (bool), `hasGoMod` (bool), `commitTime` |
+| `packages`       | `path`, `name`, `synopsis`, `isRedistributable` (bool)                             |
+| `imported-by`    | `path` (the importing package path)                                                |
+| `symbols`        | `name`, `kind` (`Function`/`Method`/`Type`/`Variable`/`Constant`), `synopsis`, `parent` |
+| `vulns`          | `ID`, `package`, `Details`                                                         |
+| `major-versions` | `modulePath`, `major`, `version`, `isLatest` (bool)                                |
+
+> [!NOTE]
+> Identifiers follow the pkg.go.dev API's filter schema, and the casing is not uniform across
+> commands — most use the lowercase JSON field name, but `vulns` uses Go-style names (`ID`, not
+> `id`). `kind` values are capitalized (`Function`, not `func`). An unknown identifier is rejected
+> by the API with `HTTP 400 undefined identifier: <name>`, which names the offending field.
 
 ## 📫 MCP server
 

--- a/cmd/godig/commands.go
+++ b/cmd/godig/commands.go
@@ -27,8 +27,13 @@ func init() {
 			parent = &cobra.Command{
 				Use:   group,
 				Short: spec.GroupShort(group),
-				// Running the parent (or an unknown subcommand) shows its help.
-				RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+				// Running the parent (or an unknown subcommand) shows its help and
+				// signals a usage error (errHelpShown -> exit 2): a bare group like
+				// `godig package` is a mistake, not a successful no-op.
+				RunE: func(cmd *cobra.Command, _ []string) error {
+					_ = cmd.Help()
+					return errHelpShown
+				},
 			}
 			parents[group] = parent
 			rootCmd.AddCommand(parent)

--- a/cmd/godig/commands.go
+++ b/cmd/godig/commands.go
@@ -27,7 +27,7 @@ func init() {
 			parent = &cobra.Command{
 				Use:   group,
 				Short: spec.GroupShort(group),
-				// Running the parent (or an unknown subcommand) shows its help and
+				// Running the parent shows its help and
 				// signals a usage error (errHelpShown -> exit 2): a bare group like
 				// `godig package` is a mistake, not a successful no-op.
 				RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/godig/root.go
+++ b/cmd/godig/root.go
@@ -50,9 +50,11 @@ func run() int {
 	if err == nil {
 		return 0
 	}
-	// Invalid args/flags already printed the full help (see argsOrHelp); exit cleanly.
+	// Invalid args/flags or a group invoked without a subcommand already printed
+	// the full help (see argsOrHelp / the group RunE). It is a usage error, so
+	// exit 2 (Unix convention) — not 0, which would hide the mistake from scripts.
 	if errors.Is(err, errHelpShown) {
-		return 0
+		return 2
 	}
 	fmt.Fprintln(os.Stderr, "godig:", err)
 	return 1

--- a/cmd/godig/root.go
+++ b/cmd/godig/root.go
@@ -56,6 +56,13 @@ func run() int {
 	if errors.Is(err, errHelpShown) {
 		return 2
 	}
+	// A dispatcher validation failure (e.g. a non-positive --limit) is likewise a
+	// usage error: print the message and exit 2, consistent with bad flags above.
+	var usage *dispatch.UsageError
+	if errors.As(err, &usage) {
+		fmt.Fprintln(os.Stderr, "godig:", err)
+		return 2
+	}
 	fmt.Fprintln(os.Stderr, "godig:", err)
 	return 1
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -39,15 +39,49 @@ func (d *Dispatcher) Invoke(ctx context.Context, name string, a map[string]any) 
 	return res, friendlyError(err, name, str(a, "path"), str(a, "version"))
 }
 
+// UsageError marks an invalid-argument error (e.g. a non-positive --limit) so the
+// CLI can map it to exit code 2 — a usage error, consistent with Cobra's handling
+// of missing/invalid flags. The MCP server surfaces it like any other tool error.
+type UsageError struct{ msg string }
+
+func (e *UsageError) Error() string { return e.msg }
+
 // validateArgs rejects out-of-range generic arguments before any network call.
 // A "limit" key is only present when the caller passed it explicitly (the CLI
-// reports only changed flags; MCP reports only provided args), so a non-positive
-// value is always a mistake — silently treating it as "unlimited" hides the bug.
+// reports only changed flags; MCP reports only provided args), so anything that
+// is not a positive integer is a mistake — silently treating 0/negative as
+// "unlimited" (or truncating a fractional 1.5 to 1) would hide the bug.
 func validateArgs(a map[string]any) error {
-	if v, ok := a["limit"]; ok && intOf(a, "limit") <= 0 {
-		return fmt.Errorf("limit must be a positive integer, got %v", v)
+	v, ok := a["limit"]
+	if !ok {
+		return nil
+	}
+	if n, ok := limitOf(v); !ok || n <= 0 {
+		return &UsageError{msg: fmt.Sprintf("limit must be a positive integer, got %v", v)}
 	}
 	return nil
+}
+
+// limitOf coerces a generic limit value (CLI int, MCP JSON float64, or a numeric
+// string) to an int, reporting false for a non-integer value such as 1.5 — which
+// intOf would otherwise silently truncate.
+func limitOf(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		if n != float64(int64(n)) {
+			return 0, false
+		}
+		return int(n), true
+	case string:
+		i, err := strconv.Atoi(n)
+		return i, err == nil
+	default:
+		return 0, false
+	}
 }
 
 // friendlyError turns ogen's "unexpected status code" errors into readable

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -32,8 +32,22 @@ func New(c *pkggodev.Client) *Dispatcher { return &Dispatcher{c: c} }
 // the given arguments, returning the typed (JSON-serialisable) response. HTTP
 // status errors are translated into friendly messages.
 func (d *Dispatcher) Invoke(ctx context.Context, name string, a map[string]any) (any, error) {
+	if err := validateArgs(a); err != nil {
+		return nil, err
+	}
 	res, err := d.route(ctx, name, a)
 	return res, friendlyError(err, name, str(a, "path"), str(a, "version"))
+}
+
+// validateArgs rejects out-of-range generic arguments before any network call.
+// A "limit" key is only present when the caller passed it explicitly (the CLI
+// reports only changed flags; MCP reports only provided args), so a non-positive
+// value is always a mistake — silently treating it as "unlimited" hides the bug.
+func validateArgs(a map[string]any) error {
+	if v, ok := a["limit"]; ok && intOf(a, "limit") <= 0 {
+		return fmt.Errorf("limit must be a positive integer, got %v", v)
+	}
+	return nil
 }
 
 // friendlyError turns ogen's "unexpected status code" errors into readable
@@ -339,6 +353,11 @@ func (d *Dispatcher) symbolExamples(ctx context.Context, path, sym string, opts 
 	s, err := d.c.Symbol(ctx, path, sym, append(opts, pkggodev.WithExamples())...)
 	if err != nil {
 		return nil, err
+	}
+	if s.Examples == nil {
+		// Non-nil so a symbol with no examples renders as "(no results)" / "[]"
+		// instead of a bare "null" (consistent with the listing operations).
+		return []pkggodev.Example{}, nil
 	}
 	return s.Examples, nil
 }

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -394,3 +394,46 @@ func TestInvoke_UnknownOperation(t *testing.T) {
 	_, err := d.Invoke(context.Background(), "nope", map[string]any{})
 	require.Error(t, err)
 }
+
+// A non-positive limit is a caller mistake (it would otherwise be silently
+// treated as "unlimited"); it must error before any network call is made.
+func TestInvoke_RejectsNonPositiveLimit(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no request expected for an invalid limit, got %s", r.URL.Path)
+	})
+	for _, lim := range []any{0, -5, float64(0), float64(-1)} {
+		_, err := d.Invoke(context.Background(), "versions", map[string]any{
+			"path":  "github.com/samber/lo",
+			"limit": lim,
+		})
+		require.Error(t, err, "limit %v", lim)
+		assert.Contains(t, err.Error(), "limit must be a positive integer")
+	}
+}
+
+// A symbol with no examples must yield a non-nil empty slice so it renders as an
+// empty list rather than a bare "null".
+func TestInvoke_SymbolExamples_EmptyNotNil(t *testing.T) {
+	t.Parallel()
+	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Doc with a symbol but no Example blocks.
+		body, _ := json.Marshal(map[string]any{
+			"path": "demo/pkg",
+			"name": "demo",
+			"docs": "## func Foo\n\n```go\nfunc Foo()\n```\n",
+		})
+		_, _ = w.Write(body)
+	})
+
+	out, err := d.Invoke(context.Background(), "symbol-examples", map[string]any{
+		"path":   "demo/pkg",
+		"symbol": "Foo",
+	})
+	require.NoError(t, err)
+	examples, ok := out.([]pkggodev.Example)
+	require.True(t, ok, "expected []pkggodev.Example, got %T", out)
+	assert.NotNil(t, examples)
+	assert.Empty(t, examples)
+}

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -402,7 +402,7 @@ func TestInvoke_RejectsNonPositiveLimit(t *testing.T) {
 	d := newDispatcher(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("no request expected for an invalid limit, got %s", r.URL.Path)
 	})
-	for _, lim := range []any{0, -5, float64(0), float64(-1)} {
+	for _, lim := range []any{0, -5, float64(0), float64(-1), float64(1.5)} {
 		_, err := d.Invoke(context.Background(), "versions", map[string]any{
 			"path":  "github.com/samber/lo",
 			"limit": lim,

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -68,18 +68,7 @@ func writeTable(w io.Writer, v any) error {
 	case []any:
 		return rowsTable(w, t)
 	case map[string]any:
-		// Prefer the first array-of-objects field (e.g. results, versions).
-		for _, k := range sortedKeys(t) {
-			if arr, ok := t[k].([]any); ok && len(arr) > 0 {
-				if _, ok := arr[0].(map[string]any); ok {
-					if _, err := fmt.Fprintf(w, "%s:\n", k); err != nil {
-						return err
-					}
-					return rowsTable(w, arr)
-				}
-			}
-		}
-		return kvTable(w, t)
+		return mapSections(w, t)
 	default:
 		return Write(w, v, "json")
 	}
@@ -116,6 +105,68 @@ func rowsTable(w io.Writer, rows []any) error {
 		}
 	}
 	return tw.Flush()
+}
+
+// mapSections renders an object that may mix scalar fields with one or more
+// arrays-of-objects (e.g. `dependencies`: modulePath/version/goVersion plus
+// requires/replaces/excludes). Scalar fields print first as a key/value table,
+// then each object-array prints under its field name — so nothing is dropped, as
+// happened when only the first array was shown. Objects with no array-of-objects
+// field (e.g. `module info`, `overview`) fall back to a plain key/value table.
+func mapSections(w io.Writer, obj map[string]any) error {
+	scalars, sections := splitSections(obj)
+	if len(sections) == 0 {
+		return kvTable(w, obj)
+	}
+	if len(scalars) > 0 {
+		if err := kvTable(w, scalars); err != nil {
+			return err
+		}
+	}
+	for _, s := range sections {
+		if _, err := fmt.Fprintf(w, "\n%s:\n", s.name); err != nil {
+			return err
+		}
+		if err := rowsTable(w, s.rows); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// section is a named array-of-objects field rendered as its own table.
+type section struct {
+	name string
+	rows []any
+}
+
+// splitSections partitions an object into its scalar fields and its
+// arrays-of-objects (each rendered as its own table/section), preserving the
+// rows so callers need no further type assertion.
+func splitSections(obj map[string]any) (scalars map[string]any, sections []section) {
+	scalars = map[string]any{}
+	for _, k := range sortedKeys(obj) {
+		if rows, ok := objectArray(obj[k]); ok {
+			sections = append(sections, section{name: k, rows: rows})
+		} else {
+			scalars[k] = obj[k]
+		}
+	}
+	return scalars, sections
+}
+
+// objectArray returns v as a row slice when it is a non-empty []any whose first
+// element is an object (map) — i.e. a value that renders as a table rather than a
+// scalar — and reports false otherwise.
+func objectArray(v any) ([]any, bool) {
+	arr, ok := v.([]any)
+	if !ok || len(arr) == 0 {
+		return nil, false
+	}
+	if _, ok := arr[0].(map[string]any); !ok {
+		return nil, false
+	}
+	return arr, true
 }
 
 // kvTable renders a flat object as key/value rows.
@@ -170,16 +221,20 @@ func markdown(v any) string {
 	case []any:
 		mdRows(&sb, t)
 	case map[string]any:
-		for _, k := range sortedKeys(t) {
-			if arr, ok := t[k].([]any); ok && len(arr) > 0 {
-				if _, ok := arr[0].(map[string]any); ok {
-					fmt.Fprintf(&sb, "## %s\n\n", k)
-					mdRows(&sb, arr)
-					return sb.String()
-				}
-			}
+		scalars, sections := splitSections(t)
+		if len(sections) == 0 {
+			mdKV(&sb, t)
+			break
 		}
-		mdKV(&sb, t)
+		if len(scalars) > 0 {
+			mdKV(&sb, scalars)
+			sb.WriteString("\n")
+		}
+		for _, s := range sections {
+			fmt.Fprintf(&sb, "## %s\n\n", s.name)
+			mdRows(&sb, s.rows)
+			sb.WriteString("\n")
+		}
 	default:
 		jb, _ := json.MarshalIndent(v, "", "  ")
 		fmt.Fprintf(&sb, "```json\n%s\n```\n", jb)

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -123,8 +123,15 @@ func mapSections(w io.Writer, obj map[string]any) error {
 			return err
 		}
 	}
-	for _, s := range sections {
-		if _, err := fmt.Fprintf(w, "\n%s:\n", s.name); err != nil {
+	for i, s := range sections {
+		// Blank line between blocks, but not before the first one when no scalar
+		// header preceded it (avoids a leading blank line for, e.g., {results:[...]}).
+		if i > 0 || len(scalars) > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "%s:\n", s.name); err != nil {
 			return err
 		}
 		if err := rowsTable(w, s.rows); err != nil {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -47,6 +47,8 @@ func TestWrite_TableNestedResults(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "results:")
 	assert.Contains(t, out, "github.com/samber/lo")
+	// No leading blank line when no scalar header precedes the first section.
+	assert.False(t, strings.HasPrefix(out, "\n"), "unexpected leading blank line")
 }
 
 // A dependencies-shaped object mixes scalar fields with several arrays-of-objects;

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -49,6 +49,42 @@ func TestWrite_TableNestedResults(t *testing.T) {
 	assert.Contains(t, out, "github.com/samber/lo")
 }
 
+// A dependencies-shaped object mixes scalar fields with several arrays-of-objects;
+// every scalar and every section must render, not just the first array.
+func TestWrite_TableMapSections(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	resp := map[string]any{
+		"modulePath": "github.com/x/y",
+		"version":    "v1.2.3",
+		"goVersion":  "1.21",
+		"requires":   []map[string]any{{"path": "github.com/a/b", "version": "v1.0.0"}},
+		"replaces":   []map[string]any{{"oldPath": "github.com/a/b", "newPath": "./local"}},
+	}
+	require.NoError(t, render.Write(&buf, resp, "table"))
+	out := buf.String()
+	assert.Contains(t, out, "goVersion") // scalar kept (was dropped before)
+	assert.Contains(t, out, "1.21")
+	assert.Contains(t, out, "requires:")
+	assert.Contains(t, out, "replaces:") // second section kept
+	assert.Contains(t, out, "./local")
+}
+
+func TestWrite_MarkdownMapSections(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	resp := map[string]any{
+		"goVersion": "1.21",
+		"requires":  []map[string]any{{"path": "github.com/a/b", "version": "v1.0.0"}},
+		"replaces":  []map[string]any{{"oldPath": "github.com/a/b", "newPath": "./local"}},
+	}
+	require.NoError(t, render.Write(&buf, resp, "md"))
+	out := buf.String()
+	assert.Contains(t, out, "| goVersion | 1.21 |")
+	assert.Contains(t, out, "## requires")
+	assert.Contains(t, out, "## replaces")
+}
+
 func TestWrite_UnknownFormat(t *testing.T) {
 	t.Parallel()
 	err := render.Write(&strings.Builder{}, 1, "xml")

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -56,7 +56,7 @@ var (
 	pVersion = Param{"version", String, "Module version (semver, 'latest', 'master' or 'main')"}
 	pModule  = Param{"module", String, "Module path"}
 	pLimit   = Param{"limit", Int, "Maximum number of items to return"}
-	pFilter  = Param{"filter", String, "Filter results with a Go boolean expression (see pkg.go.dev API docs)"}
+	pFilter  = Param{"filter", String, `Filter results with a Go boolean expression over each item's fields, e.g. 'hasPrefix(packagePath, "github.com/")' or 'kind == "Function"'. Field names are the item's JSON keys (see README "Filters").`}
 	pGOOS    = Param{"goos", String, "GOOS documentation build context"}
 	pGOARCH  = Param{"goarch", String, "GOARCH documentation build context"}
 )

--- a/tests/godig_test.go
+++ b/tests/godig_test.go
@@ -126,7 +126,7 @@ func TestSearch_RequiresQueryArg(t *testing.T) {
 	t.Parallel()
 	srv := fakeAPI(t)
 	res := run(t, srv.URL, "", "search") // missing <query>
-	assert.Equal(t, 0, res.code)
+	assert.Equal(t, 2, res.code)         // usage error
 	assert.Contains(t, res.stdout, "Usage:")
 	assert.Contains(t, res.stdout, "godig search <query>")
 }
@@ -187,9 +187,25 @@ func TestInvalidArgs_ShowsHelp(t *testing.T) {
 	t.Parallel()
 	srv := fakeAPI(t)
 	res := run(t, srv.URL, "", "imported-by") // missing <path>
-	assert.Equal(t, 0, res.code)
+	assert.Equal(t, 2, res.code)              // usage error
 	assert.Contains(t, res.stdout, "Usage:")
 	assert.Contains(t, res.stdout, "godig imported-by <path>")
+}
+
+func TestGroupWithoutSubcommand_IsUsageError(t *testing.T) {
+	t.Parallel()
+	srv := fakeAPI(t)
+	res := run(t, srv.URL, "", "package") // group, no subcommand
+	assert.Equal(t, 2, res.code)
+	assert.Contains(t, res.stdout, "Usage:")
+}
+
+func TestNonPositiveLimit_IsError(t *testing.T) {
+	t.Parallel()
+	srv := fakeAPI(t)
+	res := run(t, srv.URL, "", "versions", "github.com/samber/lo", "--limit", "0")
+	assert.Equal(t, 1, res.code)
+	assert.Contains(t, res.stderr, "limit must be a positive integer")
 }
 
 func TestMCP_Stdio_ToolsList(t *testing.T) {

--- a/tests/godig_test.go
+++ b/tests/godig_test.go
@@ -204,7 +204,7 @@ func TestNonPositiveLimit_IsError(t *testing.T) {
 	t.Parallel()
 	srv := fakeAPI(t)
 	res := run(t, srv.URL, "", "versions", "github.com/samber/lo", "--limit", "0")
-	assert.Equal(t, 1, res.code)
+	assert.Equal(t, 2, res.code) // usage error
 	assert.Contains(t, res.stderr, "limit must be a positive integer")
 }
 


### PR DESCRIPTION
## Summary

Fixes several CLI/MCP inconsistencies surfaced while auditing every command (against `github.com/samber/oops` and `github.com/samber/ro`). All changes are shared through the dispatcher/renderer, so the CLI and the MCP server benefit equally.

## Fixes

- **Exit codes** — usage errors (missing/extra positional args, invalid flags, a group like `godig package` invoked without a subcommand) exited `0`, hiding the mistake from scripts/CI. They now exit `2` (Unix convention). Runtime errors stay `1`, success `0`.
- **`--limit` validation** — a non-positive value (`0` or negative) was silently treated as *unlimited*. It is now rejected with a clear error *before* any network call, in the shared dispatcher (CLI + MCP).
- **`dependencies` rendering** — table/markdown output dropped everything but the first array, hiding the `go` directive, `modulePath`/`version` and `replaces`/`excludes`. The renderer now prints scalar fields plus **every** array-of-objects section, matching the command's help and the JSON shape (verified on `hashicorp/consul`, which has all three sections).
- **`symbol examples` / `package examples --symbol`** with no examples rendered a bare `null`; they now return a non-nil empty slice → `(no results)` / `[]` / `_(no results)_`.
- **Filters** — added a **Filters** section to the README documenting the syntax, the per-command field names (which differ and have non-uniform casing in the pkg.go.dev API), and the `HTTP 400 undefined identifier` behaviour. The `--filter` help text now points to it. All documented examples were run against the live API.

## Docs

Also documented the previously-undocumented `--exclude-pseudo` flag, the utility commands (`version`, `completion`) and the exit-code convention in the README.

## Tests & quality

- New unit/integration tests: exit `2` for a group without a subcommand, non-positive `--limit` rejection (CLI + dispatcher), `dependencies` multi-section rendering in table **and** markdown, and `symbol examples` empty-not-null.
- `gofmt` clean · `go vet` OK · `golangci-lint` 0 issues · full suite green.
