### PR TITLE
feat(plugin): declare Claude Code plugin for the pkg-go-dev MCP server

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "godig",
+  "description": "MCP server for exploring Go packages and modules via pkg.go.dev: search, documentation, symbols, versions, importers and vulnerabilities. Read-only, no authentication.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Samuel Berthe",
+    "url": "https://github.com/samber"
+  },
+  "homepage": "https://github.com/samber/godig",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samber/godig"
+  },
+  "license": "MIT",
+  "keywords": [
+    "go",
+    "golang",
+    "pkg.go.dev",
+    "package",
+    "module",
+    "documentation",
+    "mcp"
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "pkg-go-dev": {
+      "type": "http",
+      "url": "https://godig.samber.dev/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Declares `godig` as a **Claude Code plugin** that ships the public **pkg-go-dev MCP server**, so it can be installed directly and listed in a marketplace repo (e.g. `samber/cc`).

## Changes

- `.claude-plugin/plugin.json` — plugin manifest (name, metadata, MIT license, keywords).
- `.mcp.json` — declares the `pkg-go-dev` MCP server pointing at the public HTTP instance `https://godig.samber.dev/mcp` (no local binary required).

Note: this publishes the **MCP server only** — the companion skill `golang-pkg-go-dev` is already shipped via [`samber/cc-skills-golang`](https://github.com/samber/cc-skills-golang).

## Marketplace usage

Once merged, a marketplace repo references it via `.claude-plugin/marketplace.json`:

```json
{
  "plugins": [
    {
      "name": "godig",
      "source": { "type": "git", "url": "https://github.com/samber/godig", "ref": "main" },
      "description": "MCP server for exploring Go packages and modules via pkg.go.dev"
    }
  ]
}
```